### PR TITLE
docs: Add Doxygen annotations across gameplay utilities

### DIFF
--- a/Source/CoffeeLibrary/Actor/Private/AListActorManager.cpp
+++ b/Source/CoffeeLibrary/Actor/Private/AListActorManager.cpp
@@ -10,6 +10,7 @@
 #endif
 
 #if WITH_EDITOR
+/** @brief 현재 에디터 선택에서 조건을 만족하는 액터를 수집한다. */
 int32 AListActorManager::GatherSelectedItem(TArray<AActor*>& Out) const
 {
 	Out.Reset();
@@ -39,6 +40,7 @@ int32 AListActorManager::GatherSelectedItem(TArray<AActor*>& Out) const
 	return Out.Num();
 }
 
+/** @brief 선택된 액터를 배열에 추가하거나 교체한다. */
 void AListActorManager::AssignInternal(const bool bAppend)
 {
 	TArray<AActor*> Picked;
@@ -69,6 +71,7 @@ void AListActorManager::AssignInternal(const bool bAppend)
 }
 #endif // WITH_EDITOR
 
+/** @brief 배열을 선택 항목으로 대체한다. */
 void AListActorManager::AssignItemReplace()
 {
 #if WITH_EDITOR
@@ -76,6 +79,7 @@ void AListActorManager::AssignItemReplace()
 #endif
 }
 
+/** @brief 선택 항목을 배열 끝에 추가한다. */
 void AListActorManager::AssignItemAppend()
 {
 #if WITH_EDITOR
@@ -84,6 +88,7 @@ void AListActorManager::AssignItemAppend()
 }
 
 
+/** @brief 액터 라벨을 기준으로 오름차순 정렬한다. */
 void AListActorManager::SortByNameAsc()
 {
 #if WITH_EDITOR
@@ -103,6 +108,7 @@ void AListActorManager::SortByNameAsc()
 #endif
 }
 
+/** @brief 액터 라벨을 기준으로 내림차순 정렬한다. */
 void AListActorManager::SortByNameDesc()
 {
 #if WITH_EDITOR

--- a/Source/CoffeeLibrary/Actor/Private/UListActorComponent.cpp
+++ b/Source/CoffeeLibrary/Actor/Private/UListActorComponent.cpp
@@ -11,6 +11,7 @@
 #endif
 
 #if WITH_EDITOR
+/** @brief 현재 에디터 선택을 기반으로 조건에 맞는 액터를 수집한다. */
 int32 UListActorComponent::GatherSelectedItem(TArray<AActor*>& Out) const
 {
 	Out.Reset();
@@ -40,6 +41,7 @@ int32 UListActorComponent::GatherSelectedItem(TArray<AActor*>& Out) const
 	return Out.Num();
 }
 
+/** @brief 선택된 액터를 배열에 추가하거나 덮어쓴다. */
 void UListActorComponent::AssignInternal(const bool bAppend)
 {
 	TArray<AActor*> Picked;
@@ -70,6 +72,7 @@ void UListActorComponent::AssignInternal(const bool bAppend)
 }
 #endif // WITH_EDITOR
 
+/** @brief 배열을 선택 항목으로 대체한다. */
 void UListActorComponent::AssignItemReplace()
 {
 #if WITH_EDITOR
@@ -77,6 +80,7 @@ void UListActorComponent::AssignItemReplace()
 #endif
 }
 
+/** @brief 선택 항목을 배열 끝에 추가한다. */
 void UListActorComponent::AssignItemAppend()
 {
 #if WITH_EDITOR
@@ -85,6 +89,7 @@ void UListActorComponent::AssignItemAppend()
 }
 
 
+/** @brief 액터 라벨을 기준으로 오름차순 정렬한다. */
 void UListActorComponent::SortByNameAsc()
 {
 #if WITH_EDITOR
@@ -104,6 +109,7 @@ void UListActorComponent::SortByNameAsc()
 #endif
 }
 
+/** @brief 액터 라벨을 기준으로 내림차순 정렬한다. */
 void UListActorComponent::SortByNameDesc()
 {
 #if WITH_EDITOR

--- a/Source/CoffeeLibrary/Actor/Private/UOrbitalBehaviorComponent.cpp
+++ b/Source/CoffeeLibrary/Actor/Private/UOrbitalBehaviorComponent.cpp
@@ -3,11 +3,13 @@
 #include "UOrbitalBehaviorComponent.h"
 #include "GameFramework/Actor.h"
 
+/** @brief Tick 활성화를 설정한다. */
 UOrbitalBehaviorComponent::UOrbitalBehaviorComponent()
 {
 	PrimaryComponentTick.bCanEverTick = true;
 }
 
+/** @brief 초기 타겟 위치를 저장해 자연스러운 공전을 시작한다. */
 void UOrbitalBehaviorComponent::BeginPlay()
 {
 	Super::BeginPlay();
@@ -18,12 +20,14 @@ void UOrbitalBehaviorComponent::BeginPlay()
 	}
 }
 
+/** @brief 매 프레임 공전 처리를 실행한다. */
 void UOrbitalBehaviorComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
 {
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
 	Tick_TargetFloat(DeltaTime);
 }
 
+/** @brief 타겟을 따라 공전하며 보간 로직을 처리한다. */
 void UOrbitalBehaviorComponent::Tick_TargetFloat(float DeltaTime)
 {
 	AActor* Owner = GetOwner();
@@ -74,6 +78,7 @@ void UOrbitalBehaviorComponent::Tick_TargetFloat(float DeltaTime)
 	}
 }
 
+/** @brief 공전 대상 변경 시 내부 상태를 재설정한다. */
 void UOrbitalBehaviorComponent::SetTargetActor(AActor* NewTarget, bool bSnapAnchor, bool bPreserveOrbitPhase)
 {
 	// 동일 대상이면 무시

--- a/Source/CoffeeLibrary/Actor/Private/UTweenAnimInstance.cpp
+++ b/Source/CoffeeLibrary/Actor/Private/UTweenAnimInstance.cpp
@@ -3,6 +3,7 @@
 #include "UTweenAnimInstance.h"
 #include "Kismet/KismetMathLibrary.h"
 
+/** @brief 알파를 0~1 범위에서 증가 또는 감소시키며 트윈 상태를 업데이트한다. */
 void UTweenAnimInstance::NativeUpdateAnimation(float DeltaSeconds)
 {
 	const float AlphaStep  = DeltaSeconds / TweenDuration;
@@ -11,6 +12,7 @@ void UTweenAnimInstance::NativeUpdateAnimation(float DeltaSeconds)
 	TweenAlpha = FMath::Clamp(TweenAlpha + AlphaStep * Dir, 0.f, 1.f);
 }
 
+/** @brief Ease 커브가 유효하면 값을 보간하여 반환한다. */
 float UTweenAnimInstance::GetEasedAlpha() const
 {
 	if (EaseCurve)

--- a/Source/CoffeeLibrary/Actor/Public/AListActorManager.h
+++ b/Source/CoffeeLibrary/Actor/Public/AListActorManager.h
@@ -6,32 +6,45 @@
 #include "GameFramework/Actor.h"
 #include "AListActorManager.generated.h"
 
+/**
+ * @brief 에디터에서 배열을 구성하기 위한 도우미 액터.
+ *
+ * 컴포넌트 버전과 동일한 기능을 액터 단위로 제공한다.
+ */
 UCLASS()
 class COFFEELIBRARY_API AListActorManager : public AActor
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 public:
-	UPROPERTY(EditInstanceOnly, BlueprintReadWrite, Category="List")
-	TArray<AActor*> ArrayActors;
+        /** @brief 수집된 액터 목록. */
+        UPROPERTY(EditInstanceOnly, BlueprintReadWrite, Category="List")
+        TArray<AActor*> ArrayActors;
 
-	UPROPERTY(EditAnywhere, Category="List")
-	TSubclassOf<AActor> ClassFilter;	
+        /** @brief 허용할 액터 클래스 필터. */
+        UPROPERTY(EditAnywhere, Category="List")
+        TSubclassOf<AActor> ClassFilter;
 
-	UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Assign Item (Replace)"))
-	void AssignItemReplace();
+        /** @brief 현재 선택된 액터로 목록을 덮어쓴다. */
+        UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Assign Item (Replace)"))
+        void AssignItemReplace();
 
-	UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Assign Item (Append)"))
-	void AssignItemAppend();
+        /** @brief 현재 선택된 액터를 목록에 추가한다. */
+        UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Assign Item (Append)"))
+        void AssignItemAppend();
 
-	UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Sort by Name (Asc)"))
-	void SortByNameAsc();
+        /** @brief 액터 라벨 기준 오름차순 정렬. */
+        UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Sort by Name (Asc)"))
+        void SortByNameAsc();
 
-	UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Sort by Name (Desc)"))
-	void SortByNameDesc();
+        /** @brief 액터 라벨 기준 내림차순 정렬. */
+        UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Sort by Name (Desc)"))
+        void SortByNameDesc();
 
 #if WITH_EDITOR
 protected:
-	int32 GatherSelectedItem(TArray<AActor*>& Out) const;
-	void AssignInternal(bool bAppend);
+        /** @brief 에디터 선택에서 조건을 만족하는 액터를 모은다. */
+        int32 GatherSelectedItem(TArray<AActor*>& Out) const;
+        /** @brief 내부 헬퍼: Append/Replace 모드 처리. */
+        void AssignInternal(bool bAppend);
 #endif
 };

--- a/Source/CoffeeLibrary/Actor/Public/UListActorComponent.h
+++ b/Source/CoffeeLibrary/Actor/Public/UListActorComponent.h
@@ -5,34 +5,45 @@
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
 #include "UListActorComponent.generated.h"
-
-
+/**
+ * @brief 에디터에서 선택한 액터를 배열로 수집하는 편의 컴포넌트.
+ *
+ * 배열 정렬과 추가 방식을 UI 버튼 형태(CallInEditor)로 제공한다.
+ */
 UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
 class COFFEELIBRARY_API UListActorComponent : public UActorComponent
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 public:
-	UPROPERTY(EditInstanceOnly, BlueprintReadWrite, Category="List")
-	TArray<AActor*> ArrayActors;
+        /** @brief 수집된 액터 목록. */
+        UPROPERTY(EditInstanceOnly, BlueprintReadWrite, Category="List")
+        TArray<AActor*> ArrayActors;
 
-	UPROPERTY(EditAnywhere, Category="List")
-	TSubclassOf<AActor> ClassFilter;	
+        /** @brief 허용할 액터 클래스 필터. 비어 있으면 전체 허용. */
+        UPROPERTY(EditAnywhere, Category="List")
+        TSubclassOf<AActor> ClassFilter;
 
-	UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Assign Item (Replace)"))
-	void AssignItemReplace();
+        /** @brief 현재 선택된 액터로 배열을 덮어쓴다. */
+        UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Assign Item (Replace)"))
+        void AssignItemReplace();
 
-	UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Assign Item (Append)"))
-	void AssignItemAppend();
+        /** @brief 현재 선택된 액터를 배열에 추가한다. */
+        UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Assign Item (Append)"))
+        void AssignItemAppend();
 
-	UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Sort by Name (Asc)"))
-	void SortByNameAsc();
+        /** @brief 액터 라벨 기준 오름차순 정렬. */
+        UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Sort by Name (Asc)"))
+        void SortByNameAsc();
 
-	UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Sort by Name (Desc)"))
-	void SortByNameDesc();
+        /** @brief 액터 라벨 기준 내림차순 정렬. */
+        UFUNCTION(CallInEditor, Category="List", meta=(DevelopmentOnly, DisplayName="Sort by Name (Desc)"))
+        void SortByNameDesc();
 
 #if WITH_EDITOR
 protected:
-	int32 GatherSelectedItem(TArray<AActor*>& Out) const;
-	void AssignInternal(bool bAppend);
+        /** @brief 현재 에디터 선택에서 대상 액터를 수집한다. */
+        int32 GatherSelectedItem(TArray<AActor*>& Out) const;
+        /** @brief 내부 헬퍼: Append/Replace 모드를 처리한다. */
+        void AssignInternal(bool bAppend);
 #endif
 };

--- a/Source/CoffeeLibrary/Actor/Public/UOrbitalBehaviorComponent.h
+++ b/Source/CoffeeLibrary/Actor/Public/UOrbitalBehaviorComponent.h
@@ -6,72 +6,79 @@
 #include "Components/ActorComponent.h"
 #include "UOrbitalBehaviorComponent.generated.h"
 
+/**
+ * @brief 지정된 타겟을 중심으로 공전하며 움직이는 보조 오브젝트 컴포넌트.
+ *
+ * 타겟 추적, 공전 각도, 바운스 등의 움직임을 한 번에 제어한다.
+ */
 UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
 class COFFEELIBRARY_API UOrbitalBehaviorComponent : public UActorComponent
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 public:
-	UOrbitalBehaviorComponent();
+        UOrbitalBehaviorComponent();
 
-	/** 타겟 중심(앵커) 보간 속도. 0이면 즉시 스냅 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Follow", meta=(ClampMin="0.0"))
-	float AnchorLerpSpeed = 3.f;
+        /** @brief 타겟 중심(앵커) 보간 속도. 0이면 즉시 스냅. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Follow", meta=(ClampMin="0.0"))
+        float AnchorLerpSpeed = 3.f;
 
-	/** 등속 추적 사용 시 켜기. 켜면 LerpSpeed 대신 UnitsPerSec가 적용됨 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Follow")
-	bool bUseConstantFollow = false;
+        /** @brief 등속 추적 사용 여부. true면 UnitsPerSec 기반으로 이동한다. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Follow")
+        bool bUseConstantFollow = false;
 
-	/** 등속 추적 속도(cm/s) */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Follow", meta=(EditCondition="bUseConstantFollow", ClampMin="0.0"))
-	float AnchorFollowUnitsPerSec = 800.f;
+        /** @brief 등속 추적 속도(cm/s). */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Follow", meta=(EditCondition="bUseConstantFollow", ClampMin="0.0"))
+        float AnchorFollowUnitsPerSec = 800.f;
 
-	/** 공전 기준 타겟(중심점) */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Targets")
-	AActor* TargetActor = nullptr;
+        /** @brief 공전 기준이 되는 타겟(중심점). */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Targets")
+        AActor* TargetActor = nullptr;
 
-	/** 바라볼 대상(없으면 회전 고정) */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Targets")
-	AActor* PlayerActor = nullptr;
+        /** @brief 바라볼 대상. 없으면 자체 회전을 유지한다. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Targets")
+        AActor* PlayerActor = nullptr;
 
-	/** 공전 반경 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Orbit", meta=(ClampMin="0.0"))
-	float OrbitRadius = 200.f;
+        /** @brief 공전 반경(cm). */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Orbit", meta=(ClampMin="0.0"))
+        float OrbitRadius = 200.f;
 
-	/** 타겟 중심에서의 높이 오프셋 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Orbit")
-	float HeightOffset = 0.f;
+        /** @brief 타겟 중심에서의 높이 오프셋. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Orbit")
+        float HeightOffset = 0.f;
 
-	/** 공전 각속도(도/초) — 궤도 회전에 사용 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Orbit")
-	float IdleYawSpeedDegPerSec = 90.f;
+        /** @brief 공전 각속도(도/초). */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Orbit")
+        float IdleYawSpeedDegPerSec = 90.f;
 
-	/** 상하 바운스 진폭 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Vertical")
-	float BobAmplitude = 30.f;
+        /** @brief 상하 바운스 진폭(cm). */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Vertical")
+        float BobAmplitude = 30.f;
 
-	/** 상하 바운스 빈도(Hz) */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Vertical", meta=(ClampMin="0.0"))
-	float BobSpeed = 1.2f;
+        /** @brief 상하 바운스 빈도(Hz). */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Vertical", meta=(ClampMin="0.0"))
+        float BobSpeed = 1.2f;
 
-	/** 위치 이동 시 충돌 스윕 여부 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Movement")
-	bool bSweepMovement = false;
+        /** @brief 위치 이동 시 충돌 스윕을 수행할지 여부. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Movement")
+        bool bSweepMovement = false;
 
-	/** PlayerActor가 유효할 때만 바라봄 (Yaw만 적용) */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Rotation")
-	bool bFacePlayer = true;
+        /** @brief 유효한 플레이어가 있을 때만 Yaw 회전을 맞추는지 여부. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Target Float|Rotation")
+        bool bFacePlayer = true;
 
-	/** 타겟 교체 API */
-	UFUNCTION(BlueprintCallable, Category="Target Float|Follow")
-	void SetTargetActor(AActor* NewTarget, bool bSnapAnchor = false, bool bPreserveOrbitPhase = true);
+        /** @brief 공전 타겟을 교체한다. */
+        UFUNCTION(BlueprintCallable, Category="Target Float|Follow")
+        void SetTargetActor(AActor* NewTarget, bool bSnapAnchor = false, bool bPreserveOrbitPhase = true);
 
 protected:
-	virtual void BeginPlay() override;
-	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+        /** @brief 컴포넌트 활성화 시 초기 앵커 위치를 기록한다. */
+        virtual void BeginPlay() override;
+        /** @brief 매 프레임 공전 로직을 처리한다. */
+        virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
 private:
-	// 내부 상태
+        // 내부 상태
 	float   AngleDeg  = 0.f;
 	float   TimeAcc   = 0.f;
 	FVector AnchorLoc = FVector::ZeroVector;

--- a/Source/CoffeeLibrary/Actor/Public/UTweenAnimInstance.h
+++ b/Source/CoffeeLibrary/Actor/Public/UTweenAnimInstance.h
@@ -6,33 +6,46 @@
 #include "Animation/AnimInstance.h"
 #include "UTweenAnimInstance.generated.h"
 
+/**
+ * @brief 블루프린트에서 사용할 수 있는 간단한 트윈 애님 인스턴스.
+ *
+ * 애니메이션 블루프린트에서 보간 알파를 생성하고 커브를 통해 Ease 처리된 값을 제공한다.
+ */
 UCLASS()
 class COFFEELIBRARY_API UTweenAnimInstance : public UAnimInstance
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 public:
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Tween")
-	bool bActivate = false;
+        /** @brief 트윈 진행 여부. true면 증가, false면 감소한다. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Tween")
+        bool bActivate = false;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Tween", meta=(ClampMin="0.001"))
-	float TweenDuration = 0.25f;
+        /** @brief 0~1 알파를 1회 왕복하는 데 걸리는 시간(초). */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Tween", meta=(ClampMin="0.001"))
+        float TweenDuration = 0.25f;
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Tween")
-	float TweenAlpha = 0.f;
+        /** @brief 선형 알파 값. 내부적으로 Tick 때마다 업데이트된다. */
+        UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Tween")
+        float TweenAlpha = 0.f;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Tween")
-	TObjectPtr<UCurveFloat> EaseCurve = nullptr;
-	
+        /** @brief Ease 처리를 위한 커브. 없으면 선형 알파를 그대로 사용한다. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Tween")
+        TObjectPtr<UCurveFloat> EaseCurve = nullptr;
+
 public:
-	virtual void NativeUpdateAnimation(float DeltaSeconds) override;
+        /** @brief 애니메이션 갱신 시 트윈 알파를 갱신한다. */
+        virtual void NativeUpdateAnimation(float DeltaSeconds) override;
 
-	UFUNCTION(BlueprintCallable, Category="Tween")
-	void ChangeState(bool bInActivate) { bActivate = bInActivate; }
+        /** @brief 트윈 활성화 상태를 수동으로 전환한다. */
+        UFUNCTION(BlueprintCallable, Category="Tween")
+        void ChangeState(bool bInActivate) { bActivate = bInActivate; }
 
-	UFUNCTION(BlueprintCallable, Category="Tween")
-	void ResetAlpha(float InAlpha = 0.f) { TweenAlpha = FMath::Clamp(InAlpha, 0.f, 1.f); }
+        /** @brief 현재 알파를 지정 값으로 초기화한다. */
+        UFUNCTION(BlueprintCallable, Category="Tween")
+        void ResetAlpha(float InAlpha = 0.f) { TweenAlpha = FMath::Clamp(InAlpha, 0.f, 1.f); }
 
-	UFUNCTION(BlueprintPure, Category="Tween")
-	float GetEasedAlpha() const;
+        /** @brief Ease 커브를 통과한 알파 값을 반환한다. */
+        UFUNCTION(BlueprintPure, Category="Tween")
+        float GetEasedAlpha() const;
 };

--- a/Source/CoffeeLibrary/Features/Private/UEaseComponent.cpp
+++ b/Source/CoffeeLibrary/Features/Private/UEaseComponent.cpp
@@ -2,11 +2,13 @@
 
 #include "UEaseComponent.h"
 
+/** @brief Tick 활성화를 설정한다. */
 UEaseComponent::UEaseComponent()
 {
 	PrimaryComponentTick.bCanEverTick = true;
 }
 
+/** @brief 컴포넌트 Tick에서 모든 트랙을 업데이트한다. */
 void UEaseComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
 {
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
@@ -14,6 +16,7 @@ void UEaseComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorC
 	this->UpdateTrack(DeltaTime);
 }
 
+/** @brief 등록된 모든 트랙에 대해 업데이트를 수행한다. */
 void UEaseComponent::UpdateTrack(float DeltaTime)
 {
 	for (auto& Elem : FloatTracks)
@@ -32,6 +35,7 @@ void UEaseComponent::UpdateTrack(float DeltaTime)
 	}
 }
 
+/** @brief 주어진 이름의 트랙 진행도를 반환한다. */
 float UEaseComponent::GetTrackAlpha(FName TrackName) const
 {
 	if (auto* ElemPtr = FloatTracks.Find(TrackName))
@@ -52,11 +56,13 @@ float UEaseComponent::GetTrackAlpha(FName TrackName) const
 	return 0.f;
 }
 
+/** @brief float 트랙의 현재 값을 조회한다. */
 float UEaseComponent::GetEaseFloatTrack(FName TrackName)
 {
 	return FloatTracks.Contains(TrackName) ? FloatTracks[TrackName].Current : 0.f;
 }
 
+/** @brief float 트랙을 초기화하거나 업데이트한다. */
 void UEaseComponent::SetEaseFloatTrack(FName TrackName, EEaseType EaseType, float Start, float Target, float Duration)
 {
 	FEaseFloatTrack& Track = FloatTracks.FindOrAdd(TrackName);
@@ -67,11 +73,13 @@ void UEaseComponent::SetEaseFloatTrack(FName TrackName, EEaseType EaseType, floa
 	Track.ElapsedTime = 0.f;
 }
 
+/** @brief vector 트랙의 현재 값을 조회한다. */
 FVector UEaseComponent::GetEaseVectorTrack(FName TrackName)
 {
 	return VectorTracks.Contains(TrackName) ? VectorTracks[TrackName].Current : FVector::ZeroVector;
 }
 
+/** @brief vector 트랙을 초기화하거나 업데이트한다. */
 void UEaseComponent::SetEaseVectorTrack(FName TrackName, EEaseType EaseType, FVector Start, FVector Target, float Duration)
 {
 	FEaseVectorTrack& Track = VectorTracks.FindOrAdd(TrackName);
@@ -82,11 +90,13 @@ void UEaseComponent::SetEaseVectorTrack(FName TrackName, EEaseType EaseType, FVe
 	Track.ElapsedTime = 0.f;
 }
 
+/** @brief rotator 트랙의 현재 값을 조회한다. */
 FRotator UEaseComponent::GetEaseRotatorTrack(FName TrackName)
 {
 	return RotatorTracks.Contains(TrackName) ? RotatorTracks[TrackName].Current : FRotator::ZeroRotator;
 }
 
+/** @brief rotator 트랙을 초기화하거나 업데이트한다. */
 void UEaseComponent::SetEaseRotatorTrack(FName TrackName, EEaseType EaseType, FRotator Start, FRotator Target, float Duration)
 {
 	FEaseRotatorTrack& Track = RotatorTracks.FindOrAdd(TrackName);

--- a/Source/CoffeeLibrary/Features/Private/UParabolaComponent.cpp
+++ b/Source/CoffeeLibrary/Features/Private/UParabolaComponent.cpp
@@ -2,11 +2,13 @@
 #include "DrawDebugHelpers.h"
 #include "GameFramework/Actor.h"
 
+/** @brief Tick 활성화를 설정한다. */
 UParabolaComponent::UParabolaComponent()
 {
 	PrimaryComponentTick.bCanEverTick = true;
 }
 
+/** @brief 초기화 시 모든 트랙의 시간을 리셋한다. */
 void UParabolaComponent::BeginPlay()
 {
 	Super::BeginPlay();
@@ -17,12 +19,14 @@ void UParabolaComponent::BeginPlay()
 		P.Value.ResetTime();
 }
 
+/** @brief Tick마다 트랙을 갱신한다. */
 void UParabolaComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
 {
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
 	UpdateTracks(DeltaTime);
 }
 
+/** @brief 모든 포물선 트랙의 시간을 진행시킨다. */
 void UParabolaComponent::UpdateTracks(float DeltaTime)
 {
 	for (auto& P : BallisticTracks)
@@ -33,7 +37,8 @@ void UParabolaComponent::UpdateTracks(float DeltaTime)
 
 
 
-FRotator UParabolaComponent::GetParabolaFacing( FName TrackName, bool bYawOnly, EForwardAxis ForwardAxis ) const
+/** @brief 지정된 트랙의 진행 방향을 기반으로 회전을 계산한다. */
+FRotator UParabolaComponent::GetParabolaFacing(FName TrackName, bool bYawOnly, EForwardAxis ForwardAxis) const
 {
 	if (const FParabolaBallisticTrack* Ballistic = BallisticTracks.Find(TrackName))
 	{
@@ -65,6 +70,7 @@ FRotator UParabolaComponent::GetParabolaFacing( FName TrackName, bool bYawOnly, 
 	return GetOwner()->GetActorRotation();
 }
 
+/** @brief 방향 벡터에서 회전 값을 생성한다. */
 FRotator UParabolaComponent::MakeFacingFromDir(const FVector& Direction, const bool bYawOnly, const EForwardAxis ForwardAxis) const
 {
 	FVector Dir = Direction;
@@ -106,6 +112,7 @@ FRotator UParabolaComponent::MakeFacingFromDir(const FVector& Direction, const b
 }
 
 // ---- Ballistic ----
+/** @brief 탄도 트랙을 등록하고 시간을 초기화한다. */
 void UParabolaComponent::SetBallisticParabolaTrack(FName TrackName, const FParabolaBallisticTrack& Track)
 {
 	FParabolaBallisticTrack Copy = Track;
@@ -113,6 +120,7 @@ void UParabolaComponent::SetBallisticParabolaTrack(FName TrackName, const FParab
 	BallisticTracks.FindOrAdd(TrackName) = Copy;
 }
 
+/** @brief 탄도 트랙의 현재 위치를 반환한다. */
 FVector UParabolaComponent::GetBallisticParabolaVectorTrack(FName TrackName) const
 {
 	if (const FParabolaBallisticTrack* T = BallisticTracks.Find(TrackName))
@@ -122,6 +130,7 @@ FVector UParabolaComponent::GetBallisticParabolaVectorTrack(FName TrackName) con
 	return FVector::ZeroVector;
 }
 
+/** @brief 탄도 트랙에서 특정 알파의 위치를 계산한다. */
 FVector UParabolaComponent::GetBallisticVectorAtAlphaFromTrack(FName TrackName, float Alpha) const
 {
 	if (const FParabolaBallisticTrack* T = BallisticTracks.Find(TrackName))
@@ -131,6 +140,7 @@ FVector UParabolaComponent::GetBallisticVectorAtAlphaFromTrack(FName TrackName, 
 	return FVector::ZeroVector;
 }
 
+/** @brief 탄도 트랙을 디버그 라인으로 그린다. */
 void UParabolaComponent::DrawBallisticPath(FName TrackName, int32 NumSegments, FColor Color, float LifeTime) const
 {
 	if (const FParabolaBallisticTrack* T = BallisticTracks.Find(TrackName))
@@ -162,6 +172,7 @@ void UParabolaComponent::DrawBallisticPath(FName TrackName, int32 NumSegments, F
 
 
 // ---- Geometric ----
+/** @brief 기하학 트랙을 등록하고 시간을 초기화한다. */
 void UParabolaComponent::SetGeometricParabolaTrack(FName TrackName, const FParabolaGeometricTrack& Track)
 {
 	FParabolaGeometricTrack Copy = Track;
@@ -169,6 +180,7 @@ void UParabolaComponent::SetGeometricParabolaTrack(FName TrackName, const FParab
 	GeometricTracks.FindOrAdd(TrackName) = Copy;
 }
 
+/** @brief 기하학 트랙의 현재 위치를 반환한다. */
 FVector UParabolaComponent::GetGeometricParabolaVectorTrack(FName TrackName) const
 {
 	if (const FParabolaGeometricTrack* T = GeometricTracks.Find(TrackName))
@@ -178,6 +190,7 @@ FVector UParabolaComponent::GetGeometricParabolaVectorTrack(FName TrackName) con
 	return FVector::ZeroVector;
 }
 
+/** @brief 기하학 트랙에서 특정 알파의 위치를 계산한다. */
 FVector UParabolaComponent::GetGeometricVectorAtAlphaFromTrack(FName TrackName, float Alpha) const
 {
 	if (const FParabolaGeometricTrack* T = GeometricTracks.Find(TrackName))
@@ -187,7 +200,8 @@ FVector UParabolaComponent::GetGeometricVectorAtAlphaFromTrack(FName TrackName, 
 	return FVector::ZeroVector;
 }
 
-void UParabolaComponent::DrawGeometricPath(FName TrackName, int32 NumSegments, FColor Color, float LifeTime ) const
+/** @brief 기하학 트랙을 디버그 라인으로 그린다. */
+void UParabolaComponent::DrawGeometricPath(FName TrackName, int32 NumSegments, FColor Color, float LifeTime) const
 {
 	if (const FParabolaGeometricTrack* T = GeometricTracks.Find(TrackName))
 	{

--- a/Source/CoffeeLibrary/Features/Public/UCommonFunctionLibrary.h
+++ b/Source/CoffeeLibrary/Features/Public/UCommonFunctionLibrary.h
@@ -5,37 +5,47 @@
 #include "Kismet/BlueprintFunctionLibrary.h"
 #include "UCommonFunctionLibrary.generated.h"
 
+/**
+ * @brief 프로젝트 전반에서 사용하는 공통 블루프린트 함수.
+ */
 UCLASS()
 class COFFEELIBRARY_API UCommonFunctionLibrary : public UBlueprintFunctionLibrary
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 public:
 	// static void TestULog();
 	// static void TestInBound();
 
-	UFUNCTION(BlueprintPure, Category = "CoffeeLibrary|Utilities", meta = (DisplayName = "InBounds"))
-	static bool InBounds(const int32 Index, const int32 Count);
+        /** @brief 주어진 인덱스가 배열 범위 안에 있는지 확인한다. */
+        UFUNCTION(BlueprintPure, Category = "CoffeeLibrary|Utilities", meta = (DisplayName = "InBounds"))
+        static bool InBounds(const int32 Index, const int32 Count);
 
-	UFUNCTION(BlueprintPure, Category="Utils|Array", meta=(CompactNodeTitle="RandElem", ArrayParm="TargetArray", ArrayTypeDependentParams="ReturnValue"))
-	static int32 GetRandomIndex(const TArray<int32>& TargetArray, bool& bIsValid);
+        /** @brief 정수 배열에서 랜덤 인덱스를 선택한다. */
+        UFUNCTION(BlueprintPure, Category="Utils|Array", meta=(CompactNodeTitle="RandElem", ArrayParm="TargetArray", ArrayTypeDependentParams="ReturnValue"))
+        static int32 GetRandomIndex(const TArray<int32>& TargetArray, bool& bIsValid);
 
-	UFUNCTION(BlueprintPure, Category="Utils|Array", meta=(CompactNodeTitle="RandElem", ArrayParm="TargetArray", ArrayTypeDependentParams="ReturnValue"))
-	static UAnimMontage* GetRandomMontage(const TArray<UAnimMontage*>& Montages);
-	
-	UFUNCTION(BlueprintPure, Category = "CoffeeLibrary|Utilities", meta = (DisplayName = "NowTimestamp"))
-	static int64 GetNowTimestamp();	
+        /** @brief 몽타주 배열에서 랜덤 항목을 반환한다. */
+        UFUNCTION(BlueprintPure, Category="Utils|Array", meta=(CompactNodeTitle="RandElem", ArrayParm="TargetArray", ArrayTypeDependentParams="ReturnValue"))
+        static UAnimMontage* GetRandomMontage(const TArray<UAnimMontage*>& Montages);
 
-	UFUNCTION(BlueprintPure, Category="CoffeeLibrary|Utilities", meta=(DefaultToSelf="Target", DisplayName="GetDistance"))
-	static float GetDistance( AActor* A,  AActor* B);
-	
-	UFUNCTION(BlueprintCallable, Category="CoffeeLibrary|Material", meta=(DefaultToSelf="Target", DisplayName="Get Or Create MID", AdvancedDisplay="OptionalName"))
-	static class UMaterialInstanceDynamic* GetOrCreateMID(
-		class UPrimitiveComponent* Target,
-		int32 ElementIndex,
-		FName OptionalName = NAME_None);
+        /** @brief 현재 시간을 Unix Timestamp(초)로 반환한다. */
+        UFUNCTION(BlueprintPure, Category = "CoffeeLibrary|Utilities", meta = (DisplayName = "NowTimestamp"))
+        static int64 GetNowTimestamp();
 
-	UFUNCTION(BlueprintCallable, Category="CoffeeLibrary|Utilities", meta=(DefaultToSelf="Target", DisplayName="PlayCommonSound"))
-	static void PlayLocationSound(const AActor* Actor, USoundBase* Sound, const float RetriggerDelay);
+        /** @brief 두 액터 사이의 거리를 계산한다. */
+        UFUNCTION(BlueprintPure, Category="CoffeeLibrary|Utilities", meta=(DefaultToSelf="Target", DisplayName="GetDistance"))
+        static float GetDistance( AActor* A,  AActor* B);
+
+        /** @brief 머티리얼 인스턴스 다이내믹을 얻거나 새로 생성한다. */
+        UFUNCTION(BlueprintCallable, Category="CoffeeLibrary|Material", meta=(DefaultToSelf="Target", DisplayName="Get Or Create MID", AdvancedDisplay="OptionalName"))
+        static class UMaterialInstanceDynamic* GetOrCreateMID(
+                class UPrimitiveComponent* Target,
+                int32 ElementIndex,
+                FName OptionalName = NAME_None);
+
+        /** @brief 지정된 위치에서 사운드를 재생한다. */
+        UFUNCTION(BlueprintCallable, Category="CoffeeLibrary|Utilities", meta=(DefaultToSelf="Target", DisplayName="PlayCommonSound"))
+        static void PlayLocationSound(const AActor* Actor, USoundBase* Sound, const float RetriggerDelay);
 };
 

--- a/Source/CoffeeLibrary/Features/Public/UEaseComponent.h
+++ b/Source/CoffeeLibrary/Features/Public/UEaseComponent.h
@@ -7,10 +7,11 @@
 #include "Components/ActorComponent.h"
 #include "UEaseComponent.generated.h"
 
+/** @brief 단일 float 값을 시간에 따라 Ease 처리하는 트랙 데이터. */
 USTRUCT(BlueprintType)
 struct FEaseFloatTrack
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	EEaseType EaseType = EEaseType::Linear;
@@ -28,23 +29,26 @@ struct FEaseFloatTrack
 	float Duration = 1.f;
 	float ElapsedTime = 0.f;
 
-	float GetAlpha() const
-	{
-		return FMath::Clamp(Duration > 0.f ? ElapsedTime / Duration : 1.f, 0.f, 1.f);
-	}
+        /** @brief 진행도를 0~1 범위로 반환한다. */
+        float GetAlpha() const
+        {
+                return FMath::Clamp(Duration > 0.f ? ElapsedTime / Duration : 1.f, 0.f, 1.f);
+        }
 
-	void Update(float DeltaTime)
-	{
-		ElapsedTime += DeltaTime;
-		float Alpha = FMath::Clamp(Duration > 0.f ? ElapsedTime / Duration : 1.f, 0.f, 1.f);
-		Current = FMath::Lerp(Start, Target, FEaseHelper::Ease(Alpha, EaseType));
-	}
+        /** @brief 경과 시간을 누적하고 Ease 결과를 갱신한다. */
+        void Update(float DeltaTime)
+        {
+                ElapsedTime += DeltaTime;
+                float Alpha = FMath::Clamp(Duration > 0.f ? ElapsedTime / Duration : 1.f, 0.f, 1.f);
+                Current = FMath::Lerp(Start, Target, FEaseHelper::Ease(Alpha, EaseType));
+        }
 };
 
+/** @brief FVector 값을 Ease 처리하는 트랙 데이터. */
 USTRUCT(BlueprintType)
 struct FEaseVectorTrack
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	EEaseType EaseType = EEaseType::Linear;
@@ -63,23 +67,26 @@ struct FEaseVectorTrack
 
 	float ElapsedTime = 0.f;
 
-	float GetAlpha() const
-	{
-		return FMath::Clamp(Duration > 0.f ? ElapsedTime / Duration : 1.f, 0.f, 1.f);
-	}
+        /** @brief 진행도를 0~1 범위로 반환한다. */
+        float GetAlpha() const
+        {
+                return FMath::Clamp(Duration > 0.f ? ElapsedTime / Duration : 1.f, 0.f, 1.f);
+        }
 
-	void Update(float DeltaTime)
-	{
-		ElapsedTime += DeltaTime;
-		float Alpha = FMath::Clamp(Duration > 0.f ? ElapsedTime / Duration : 1.f, 0.f, 1.f);
-		Current = FMath::Lerp(Start, Target, FEaseHelper::Ease(Alpha, EaseType));
-	}
+        /** @brief 경과 시간을 누적하고 Ease 결과를 갱신한다. */
+        void Update(float DeltaTime)
+        {
+                ElapsedTime += DeltaTime;
+                float Alpha = FMath::Clamp(Duration > 0.f ? ElapsedTime / Duration : 1.f, 0.f, 1.f);
+                Current = FMath::Lerp(Start, Target, FEaseHelper::Ease(Alpha, EaseType));
+        }
 };
 
+/** @brief FRotator 값을 Ease 처리하는 트랙 데이터. */
 USTRUCT(BlueprintType)
 struct FEaseRotatorTrack
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	EEaseType EaseType = EEaseType::Linear;
@@ -98,49 +105,63 @@ struct FEaseRotatorTrack
 
 	float ElapsedTime = 0.f;
 
-	float GetAlpha() const
-	{
-		return FMath::Clamp(Duration > 0.f ? ElapsedTime / Duration : 1.f, 0.f, 1.f);
-	}
+        /** @brief 진행도를 0~1 범위로 반환한다. */
+        float GetAlpha() const
+        {
+                return FMath::Clamp(Duration > 0.f ? ElapsedTime / Duration : 1.f, 0.f, 1.f);
+        }
 
-	void Update(float DeltaTime)
-	{
-		ElapsedTime += DeltaTime;
-		float Alpha = FMath::Clamp(Duration > 0.f ? ElapsedTime / Duration : 1.f, 0.f, 1.f);
-		Current = FMath::Lerp(Start, Target, FEaseHelper::Ease(Alpha, EaseType));
-	}
+        /** @brief 경과 시간을 누적하고 Ease 결과를 갱신한다. */
+        void Update(float DeltaTime)
+        {
+                ElapsedTime += DeltaTime;
+                float Alpha = FMath::Clamp(Duration > 0.f ? ElapsedTime / Duration : 1.f, 0.f, 1.f);
+                Current = FMath::Lerp(Start, Target, FEaseHelper::Ease(Alpha, EaseType));
+        }
 };
 
 
+/**
+ * @brief 다양한 타입의 Ease 트랙을 업데이트하는 범용 컴포넌트.
+ */
 UCLASS( ClassGroup=(CoffeeLibrary), meta=(BlueprintSpawnableComponent, DisplayName="EaseComponent") )
 class COFFEELIBRARY_API UEaseComponent : public UActorComponent
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
-public:	
-	UEaseComponent();
+public:
+        UEaseComponent();
 
-public:	
-	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
-	void UpdateTrack(float DeltaTime);
+public:
+        /** @brief 매 프레임 모든 트랙을 업데이트한다. */
+        virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+        /** @brief 외부 호출용 트랙 업데이트 함수. */
+        void UpdateTrack(float DeltaTime);
 
-	UFUNCTION(BlueprintPure, Category="Track")
-	float GetTrackAlpha(FName TrankName) const;
+        /** @brief 트랙 진행도를 반환한다. */
+        UFUNCTION(BlueprintPure, Category="Track")
+        float GetTrackAlpha(FName TrankName) const;
 
-	UFUNCTION(BlueprintPure, Category="Track")
-	float GetEaseFloatTrack(FName TrackName);
-	UFUNCTION(BlueprintCallable, Category="Track")
-	void SetEaseFloatTrack(FName TrackName, EEaseType EaseType, float Start, float Target, float Duration = 1.f);
-    
-	UFUNCTION(BlueprintPure, Category="Track")
-	FVector GetEaseVectorTrack(FName TrackName);
-	UFUNCTION(BlueprintCallable, Category="Track")
-	void SetEaseVectorTrack(FName TrackName, EEaseType EaseType, FVector Start, FVector Target, float Duration = 1.f);
+        /** @brief float 트랙의 현재 값을 반환한다. */
+        UFUNCTION(BlueprintPure, Category="Track")
+        float GetEaseFloatTrack(FName TrackName);
+        /** @brief float 트랙을 설정하거나 갱신한다. */
+        UFUNCTION(BlueprintCallable, Category="Track")
+        void SetEaseFloatTrack(FName TrackName, EEaseType EaseType, float Start, float Target, float Duration = 1.f);
 
-	UFUNCTION(BlueprintPure, Category="Track")
-	FRotator GetEaseRotatorTrack(FName TrackName);
-	UFUNCTION(BlueprintCallable, Category="Track")
-	void SetEaseRotatorTrack(FName TrackName, EEaseType EaseType, FRotator Start, FRotator Target, float Duration = 1.f);
+        /** @brief vector 트랙의 현재 값을 반환한다. */
+        UFUNCTION(BlueprintPure, Category="Track")
+        FVector GetEaseVectorTrack(FName TrackName);
+        /** @brief vector 트랙을 설정하거나 갱신한다. */
+        UFUNCTION(BlueprintCallable, Category="Track")
+        void SetEaseVectorTrack(FName TrackName, EEaseType EaseType, FVector Start, FVector Target, float Duration = 1.f);
+
+        /** @brief rotator 트랙의 현재 값을 반환한다. */
+        UFUNCTION(BlueprintPure, Category="Track")
+        FRotator GetEaseRotatorTrack(FName TrackName);
+        /** @brief rotator 트랙을 설정하거나 갱신한다. */
+        UFUNCTION(BlueprintCallable, Category="Track")
+        void SetEaseRotatorTrack(FName TrackName, EEaseType EaseType, FRotator Start, FRotator Target, float Duration = 1.f);
 
 	
 private:

--- a/Source/CoffeeLibrary/Features/Public/UParabolaComponent.h
+++ b/Source/CoffeeLibrary/Features/Public/UParabolaComponent.h
@@ -7,8 +7,7 @@
 #include "Components/ActorComponent.h"
 #include "UParabolaComponent.generated.h"
 
-
-
+/** @brief 포물선 트랙 계산 방식을 정의한다. */
 enum class EParabolaType : uint8
 {
 	// 초기속도·중력 사용하는 물리식임이 즉시 읽힘.
@@ -17,13 +16,15 @@ enum class EParabolaType : uint8
 	Geometric		UMETA(DisplayName="Geometric (Apex Height)",	ToolTip="Lerp(Start,Target,a) + UpAxis * 4*H*a*(1-a)")
 };
 
+/** @brief 정면 방향 축을 지정한다. */
 UENUM(BlueprintType)
 enum class EForwardAxis : uint8 { X, Y, Z };
 
+/** @brief 물리 기반(초기 속도/중력) 포물선을 계산하는 트랙. */
 USTRUCT(BlueprintType)
 struct FParabolaBallisticTrack
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 	// 입력 파라미터
 	UPROPERTY(EditAnywhere, BlueprintReadWrite) FVector Start = FVector::ZeroVector;
@@ -39,22 +40,27 @@ struct FParabolaBallisticTrack
 	// 런타임 상태
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Transient) float CurrentTime = 0.f;
 
-	// 타임 유틸
-	FORCEINLINE void ResetTime() { CurrentTime = 0.f; }
-	FORCEINLINE float GetAlpha() const { return FMath::Clamp(CurrentTime / FMath::Max(0.001f, Duration), 0.f, 1.f); }
-	FORCEINLINE void Advance(float DeltaTime)
-	{
-		CurrentTime = FMath::Min(CurrentTime + FMath::Max(0.f, DeltaTime), FMath::Max(0.001f, Duration));
-	}
+        // 타임 유틸
+        /** @brief 시간을 0으로 초기화한다. */
+        FORCEINLINE void ResetTime() { CurrentTime = 0.f; }
+        /** @brief 현재 경과 시간의 알파를 반환한다. */
+        FORCEINLINE float GetAlpha() const { return FMath::Clamp(CurrentTime / FMath::Max(0.001f, Duration), 0.f, 1.f); }
+        /** @brief 지정한 델타만큼 시간을 진행한다. */
+        FORCEINLINE void Advance(float DeltaTime)
+        {
+                CurrentTime = FMath::Min(CurrentTime + FMath::Max(0.f, DeltaTime), FMath::Max(0.001f, Duration));
+        }
 
-	// 속도/평가
-	FORCEINLINE FVector GetInitialVelocity() const
-	{
-		return Direction.GetSafeNormal() * Power;
-	}
+        // 속도/평가
+        /** @brief 방향/파워 조합으로부터 초기 속도를 계산한다. */
+        FORCEINLINE FVector GetInitialVelocity() const
+        {
+                return Direction.GetSafeNormal() * Power;
+        }
 
-	FVector EvaluateAtTime(const AActor* /*Owner*/, float TimeSec) const
-	{
+        /** @brief 시간값을 받아 포물선 위치를 계산한다. */
+        FVector EvaluateAtTime(const AActor* /*Owner*/, float TimeSec) const
+        {
 		const float t = FMath::Clamp(TimeSec, 0.f, FMath::Max(0.001f, Duration));
 		const FVector g(0,0,GravityZ);
 		const FVector V0 = GetInitialVelocity();
@@ -65,42 +71,48 @@ struct FParabolaBallisticTrack
 		return P;
 	}
 
-	FORCEINLINE FVector EvaluateAtAlpha(const AActor* Owner, float Alpha) const
-	{
-		return EvaluateAtTime(Owner, Alpha * FMath::Max(0.001f, Duration));
-	}
+        /** @brief 알파값 기반 위치를 계산한다. */
+        FORCEINLINE FVector EvaluateAtAlpha(const AActor* Owner, float Alpha) const
+        {
+                return EvaluateAtTime(Owner, Alpha * FMath::Max(0.001f, Duration));
+        }
 
-	FORCEINLINE FVector EvaluateAtCurrent(const AActor* Owner) const
-	{
-		return EvaluateAtTime(Owner, CurrentTime);
-	}
+        /** @brief 현재 시간 기준 위치를 계산한다. */
+        FORCEINLINE FVector EvaluateAtCurrent(const AActor* Owner) const
+        {
+                return EvaluateAtTime(Owner, CurrentTime);
+        }
 
-	// 목표점+시간으로 V0 역산 → Direction/Power 세팅
-	static FVector SolveV0ForArc(const FVector& InStart, const FVector& InEnd, float t, float InGravityZ=-980.f)
-	{
-		return FMathHelper::SolveV0ForProjectile( InStart, InEnd, t, InGravityZ );
-	}
+        // 목표점+시간으로 V0 역산 → Direction/Power 세팅
+        /** @brief 목표 위치와 비행 시간으로 초기 속도를 역산한다. */
+        static FVector SolveV0ForArc(const FVector& InStart, const FVector& InEnd, float t, float InGravityZ=-980.f)
+        {
+                return FMathHelper::SolveV0ForProjectile( InStart, InEnd, t, InGravityZ );
+        }
 
-	static void SplitVelocity(const FVector& V0, FVector& OutDir, float& OutPow)
-	{
-		OutPow = V0.Length();
-		OutDir = (OutPow > SMALL_NUMBER) ? V0 / OutPow : FVector(1,0,0);
-	}
+        /** @brief 속도를 방향과 크기로 분해한다. */
+        static void SplitVelocity(const FVector& V0, FVector& OutDir, float& OutPow)
+        {
+                OutPow = V0.Length();
+                OutDir = (OutPow > SMALL_NUMBER) ? V0 / OutPow : FVector(1,0,0);
+        }
 
-	void ApplyArcSolution(const FVector& InStart, const FVector& InEnd, float t)
-	{
-		Start = InStart;
-		Duration = FMath::Max(0.001f, t);
-		const FVector V0 = SolveV0ForArc(InStart, InEnd, Duration, GravityZ);
-		SplitVelocity(V0, Direction, Power);
-		ResetTime();
-	}
+        /** @brief 시작/도착점과 시간으로 트랙 파라미터를 초기화한다. */
+        void ApplyArcSolution(const FVector& InStart, const FVector& InEnd, float t)
+        {
+                Start = InStart;
+                Duration = FMath::Max(0.001f, t);
+                const FVector V0 = SolveV0ForArc(InStart, InEnd, Duration, GravityZ);
+                SplitVelocity(V0, Direction, Power);
+                ResetTime();
+        }
 };
 
+/** @brief 정점 높이를 지정해 기하학적 포물선을 계산하는 트랙. */
 USTRUCT(BlueprintType)
 struct FParabolaGeometricTrack
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 	// 입력 파라미터
 	UPROPERTY(EditAnywhere, BlueprintReadWrite) FVector Start = FVector::ZeroVector;
@@ -116,17 +128,21 @@ struct FParabolaGeometricTrack
 	// 런타임 상태
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Transient) float CurrentTime = 0.f;
 
-	// 타임 유틸
-	FORCEINLINE void ResetTime() { CurrentTime = 0.f; }
-	FORCEINLINE float GetAlpha() const { return FMath::Clamp(CurrentTime / FMath::Max(0.001f, Duration), 0.f, 1.f); }
-	FORCEINLINE void Advance(float DeltaTime)
-	{
-		CurrentTime = FMath::Min(CurrentTime + FMath::Max(0.f, DeltaTime), FMath::Max(0.001f, Duration));
-	}
+        // 타임 유틸
+        /** @brief 시간을 0으로 초기화한다. */
+        FORCEINLINE void ResetTime() { CurrentTime = 0.f; }
+        /** @brief 현재 경과 시간의 알파를 반환한다. */
+        FORCEINLINE float GetAlpha() const { return FMath::Clamp(CurrentTime / FMath::Max(0.001f, Duration), 0.f, 1.f); }
+        /** @brief 지정한 델타만큼 시간을 진행한다. */
+        FORCEINLINE void Advance(float DeltaTime)
+        {
+                CurrentTime = FMath::Min(CurrentTime + FMath::Max(0.f, DeltaTime), FMath::Max(0.001f, Duration));
+        }
 
-	// 평가(직선보간 + 4Ha(1-a) 버프)
-	FVector EvaluateAtTime(const AActor* /*Owner*/, float TimeSec) const
-	{
+        // 평가(직선보간 + 4Ha(1-a) 버프)
+        /** @brief 시간값을 받아 포물선 위치를 계산한다. */
+        FVector EvaluateAtTime(const AActor* /*Owner*/, float TimeSec) const
+        {
 		const float D = FMath::Max(0.001f, Duration);
 		const float t = FMath::Clamp(TimeSec, 0.f, D);
 		const float a = t / D;
@@ -134,74 +150,93 @@ struct FParabolaGeometricTrack
 		return FMathHelper::InterpArcSin(Start, Target, ApexHeight, a);
 	}
 
-	FORCEINLINE FVector EvaluateAtAlpha(const AActor* Owner, float Alpha) const
-	{
-		return EvaluateAtTime(Owner, Alpha * FMath::Max(0.001f, Duration));
-	}
+        /** @brief 알파값 기반 위치를 계산한다. */
+        FORCEINLINE FVector EvaluateAtAlpha(const AActor* Owner, float Alpha) const
+        {
+                return EvaluateAtTime(Owner, Alpha * FMath::Max(0.001f, Duration));
+        }
 
-	FORCEINLINE FVector EvaluateAtCurrent(const AActor* Owner) const
-	{
-		return EvaluateAtTime(Owner, CurrentTime);
-	}
+        /** @brief 현재 시간 기준 위치를 계산한다. */
+        FORCEINLINE FVector EvaluateAtCurrent(const AActor* Owner) const
+        {
+                return EvaluateAtTime(Owner, CurrentTime);
+        }
 
-	void ApplyArcSolution(const FVector& InStart, const FVector& InTarget, const float InApexHeight, float t, const FVector& InUpAxis = FVector::UpVector)
-	{
-		Start = InStart;
-		Target = InTarget;
-		ApexHeight = FMath::Max(0.f, InApexHeight);
-		UpAxis = InUpAxis;
-		Duration = FMath::Max(0.001f, t);
-		ResetTime();
-	}
+        /** @brief 시작/도착점과 정점 높이로 트랙 파라미터를 초기화한다. */
+        void ApplyArcSolution(const FVector& InStart, const FVector& InTarget, const float InApexHeight, float t, const FVector& InUpAxis = FVector::UpVector)
+        {
+                Start = InStart;
+                Target = InTarget;
+                ApexHeight = FMath::Max(0.f, InApexHeight);
+                UpAxis = InUpAxis;
+                Duration = FMath::Max(0.001f, t);
+                ResetTime();
+        }
 };
 
 
+/**
+ * @brief 포물선 이동을 계산해 위치/회전을 제공하는 컴포넌트.
+ */
 UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
 class COFFEELIBRARY_API UParabolaComponent : public UActorComponent
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 public:
-	UParabolaComponent();
-	
+        UParabolaComponent();
+
 protected:
-	virtual void BeginPlay() override;
+        /** @brief 초기화 시 기본 설정을 수행한다. */
+        virtual void BeginPlay() override;
 
 public:
-	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
-	void UpdateTracks(float DeltaTime);
+        /** @brief 매 프레임 트랙을 업데이트한다. */
+        virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+        /** @brief 등록된 모든 트랙을 수동 업데이트한다. */
+        void UpdateTracks(float DeltaTime);
 
-	UFUNCTION(BlueprintCallable, Category="Parabola")
-	FRotator GetParabolaFacing(FName TrackName, bool bYawOnly, EForwardAxis ForwardAxis) const;
+        /** @brief 트랙 진행 방향에 맞는 회전을 계산한다. */
+        UFUNCTION(BlueprintCallable, Category="Parabola")
+        FRotator GetParabolaFacing(FName TrackName, bool bYawOnly, EForwardAxis ForwardAxis) const;
 
-	UFUNCTION(BlueprintCallable, Category="Parabola")
-	FRotator MakeFacingFromDir(const FVector& Direction, const bool bYawOnly, const EForwardAxis ForwardAxis) const;
-	
-	// --- Ballistic ---
-	UFUNCTION(BlueprintCallable, Category="Parabola|Ballistic")
-	void SetBallisticParabolaTrack(FName TrackName, const FParabolaBallisticTrack& Track);
+        /** @brief 지정된 방향 벡터에서 회전을 생성한다. */
+        UFUNCTION(BlueprintCallable, Category="Parabola")
+        FRotator MakeFacingFromDir(const FVector& Direction, const bool bYawOnly, const EForwardAxis ForwardAxis) const;
 
-	UFUNCTION(BlueprintPure, Category="Parabola|Ballistic")
-	FVector GetBallisticParabolaVectorTrack(FName TrackName) const;
+        // --- Ballistic ---
+        /** @brief 탄도 포물선 트랙을 설정한다. */
+        UFUNCTION(BlueprintCallable, Category="Parabola|Ballistic")
+        void SetBallisticParabolaTrack(FName TrackName, const FParabolaBallisticTrack& Track);
 
-	UFUNCTION(BlueprintPure, Category="Parabola|Ballistic")
-	FVector GetBallisticVectorAtAlphaFromTrack(FName TrackName, float Alpha) const;
+        /** @brief 탄도 트랙의 현재 위치를 반환한다. */
+        UFUNCTION(BlueprintPure, Category="Parabola|Ballistic")
+        FVector GetBallisticParabolaVectorTrack(FName TrackName) const;
 
-	UFUNCTION(BlueprintCallable, Category="Parabola|Ballistic")
-	void DrawBallisticPath(FName TrackName, int32 NumSegments, FColor Color, float LifeTime) const;
+        /** @brief 탄도 트랙에서 특정 알파 위치를 반환한다. */
+        UFUNCTION(BlueprintPure, Category="Parabola|Ballistic")
+        FVector GetBallisticVectorAtAlphaFromTrack(FName TrackName, float Alpha) const;
 
-	// --- Geometric ---
-	UFUNCTION(BlueprintCallable, Category="Parabola|Geometric")
-	void SetGeometricParabolaTrack(FName TrackName, const FParabolaGeometricTrack& Track);
+        /** @brief 탄도 경로를 디버그 드로우한다. */
+        UFUNCTION(BlueprintCallable, Category="Parabola|Ballistic")
+        void DrawBallisticPath(FName TrackName, int32 NumSegments, FColor Color, float LifeTime) const;
 
-	UFUNCTION(BlueprintPure, Category="Parabola|Geometric")
-	FVector GetGeometricParabolaVectorTrack(FName TrackName) const;
+        // --- Geometric ---
+        /** @brief 기하학 포물선 트랙을 설정한다. */
+        UFUNCTION(BlueprintCallable, Category="Parabola|Geometric")
+        void SetGeometricParabolaTrack(FName TrackName, const FParabolaGeometricTrack& Track);
 
-	UFUNCTION(BlueprintPure, Category="Parabola|Geometric")
-	FVector GetGeometricVectorAtAlphaFromTrack(FName TrackName, float Alpha) const;
+        /** @brief 기하학 트랙의 현재 위치를 반환한다. */
+        UFUNCTION(BlueprintPure, Category="Parabola|Geometric")
+        FVector GetGeometricParabolaVectorTrack(FName TrackName) const;
 
-	UFUNCTION(BlueprintCallable, Category="Parabola|Geometric")
-	void DrawGeometricPath(FName TrackName, int32 NumSegments, FColor Color, float LifeTime) const;
+        /** @brief 기하학 트랙에서 특정 알파 위치를 반환한다. */
+        UFUNCTION(BlueprintPure, Category="Parabola|Geometric")
+        FVector GetGeometricVectorAtAlphaFromTrack(FName TrackName, float Alpha) const;
+
+        /** @brief 기하학 경로를 디버그 드로우한다. */
+        UFUNCTION(BlueprintCallable, Category="Parabola|Geometric")
+        void DrawGeometricPath(FName TrackName, int32 NumSegments, FColor Color, float LifeTime) const;
 
 private:
 	TMap<FName, FParabolaBallisticTrack> BallisticTracks;

--- a/Source/YiSan/Environment/Private/YiSanGameMode.cpp
+++ b/Source/YiSan/Environment/Private/YiSanGameMode.cpp
@@ -2,7 +2,8 @@
 
 #include "YiSanGameMode.h"
 
+/** @brief GameMode 생성 시 필요한 최소 초기화를 수행한다. */
 AYiSanGameMode::AYiSanGameMode()
 {
-	// stub
+        // stub
 }

--- a/Source/YiSan/Environment/Public/YiSanGameMode.h
+++ b/Source/YiSan/Environment/Public/YiSanGameMode.h
@@ -7,17 +7,19 @@
 #include "YiSanGameMode.generated.h"
 
 /**
- *  Simple GameMode for a third person game
+ * @brief 간단한 서드 퍼슨 게임을 위한 기본 게임 모드.
+ *
+ * 프로젝트 공통 게임모드 기능을 파생 클래스가 확장할 수 있도록 최소 구현만 제공한다.
  */
 UCLASS(abstract)
 class AYiSanGameMode : public AGameModeBase
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 public:
-	
-	/** Constructor */
-	AYiSanGameMode();
+
+        /** @brief GameMode 기본 생성자. */
+        AYiSanGameMode();
 };
 
 

--- a/Source/YiSan/YiSan.cpp
+++ b/Source/YiSan/YiSan.cpp
@@ -3,6 +3,9 @@
 #include "YiSan.h"
 #include "Modules/ModuleManager.h"
 
-IMPLEMENT_PRIMARY_GAME_MODULE( FDefaultGameModuleImpl, YiSan, "YiSan" );
+/** @brief YiSan 게임 모듈을 초기화하는 엔트리 포인트. */
+IMPLEMENT_PRIMARY_GAME_MODULE(FDefaultGameModuleImpl, YiSan, "YiSan");
 
+/** @brief YiSan 모듈의 전역 로그 카테고리를 정의한다. */
 DEFINE_LOG_CATEGORY(LogYiSan)
+

--- a/Source/YiSan/YiSan.h
+++ b/Source/YiSan/YiSan.h
@@ -4,5 +4,10 @@
 
 #include "CoreMinimal.h"
 
-/** Main log category used across the project */
+/**
+ * @brief YiSan 모듈 전역에서 사용하는 기본 로그 카테고리.
+ *
+ * 모듈 초기화 시 정의되며 게임 시스템 전반에서 공통적으로 사용한다.
+ */
 DECLARE_LOG_CATEGORY_EXTERN(LogYiSan, Log, All);
+


### PR DESCRIPTION
## Summary
- add Doxygen-style @brief comments to CoffeeLibrary animation, orbit, ease, and parabola utilities
- document common blueprint helper functions and YiSan game module entry points for generated documentation
- synchronize source implementations with matching inline documentation for readability

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc5168f7a48329b768a8a6140b4149