### PR TITLE
Translate Doxygen comments to Korean across Coffee modules

### DIFF
--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Command/FCommandFeature.cpp
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Command/FCommandFeature.cpp
@@ -1,12 +1,18 @@
+/**
+ * @file FCommandFeature.cpp
+ * @brief Coffee Toolbar용 명령 실행 보조 기능을 구현합니다.
+ */
 #include "Command/FCommandFeature.h"
 #include "Settings/UToolbarSettings.h"
 #include "Common/FCommon.h"
 #include "ToolMenus.h"
 
+/** @brief 메뉴 상태를 생성하지 않고 기능 객체를 초기화합니다. */
 FCommandFeature::FCommandFeature()
 {
 }
 
+/** @brief 설정된 툴바 버튼 정보를 바탕으로 메뉴 위젯을 구성합니다. */
 TSharedRef<SWidget> FCommandFeature::GenerateCommandsMenu()
 {
     FMenuBuilder MenuBuilder(true, nullptr);
@@ -33,6 +39,7 @@ TSharedRef<SWidget> FCommandFeature::GenerateCommandsMenu()
     return MenuBuilder.MakeWidget();
 }
 
+/** @brief 전달된 툴바 버튼에 연결된 명령을 실행합니다. */
 void FCommandFeature::OnExecuteButtonCommand(FName ButtonId)
 {
     const UToolbarSettings* Settings = GetDefault<UToolbarSettings>();
@@ -59,6 +66,7 @@ void FCommandFeature::OnExecuteButtonCommand(FName ButtonId)
     }
 }
 
+/** @brief 지정된 토글 버튼이 현재 활성화되어 있는지 반환합니다. */
 bool FCommandFeature::IsButtonToggled(FName ButtonId) const
 {
     return ToggleButtonState.FindRef(ButtonId);

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Common/FCommon.cpp
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Common/FCommon.cpp
@@ -1,7 +1,12 @@
+/**
+ * @file FCommon.cpp
+ * @brief Coffee Toolbar 플러그인을 위한 공용 헬퍼 유틸리티를 구현합니다.
+ */
 #include "Common/FCommon.h"
 #include "Common/FToolbarStyle.h"
 #include "Framework/Application/SlateApplication.h"
 
+/** @brief 에디터 스타일 또는 플러그인 스타일 세트에서 Slate 아이콘을 찾아 반환합니다. */
 const FSlateIcon FCommon::GetIcon(FName IconName)
 {
     if (IconName.ToString().Contains(TEXT(".")))
@@ -12,6 +17,7 @@ const FSlateIcon FCommon::GetIcon(FName IconName)
     return FSlateIcon(FToolbarStyle::GetStyleSetName(), IconName);
 }
 
+/** @brief 현재 툴바 액션이 대상으로 삼는 월드를 반환합니다. */
 UWorld* FCommon::GetActiveTargetWorld()
 {
     if (GEditor && GEditor->PlayWorld)

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Common/FToolbarCommands.cpp
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Common/FToolbarCommands.cpp
@@ -1,9 +1,14 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file FToolbarCommands.cpp
+ * @brief Coffee Toolbar 플러그인의 Slate 명령 정의를 구현합니다.
+ */
 #include "Common/FToolbarCommands.h"
 
 #define LOCTEXT_NAMESPACE "FCoffeeToolbarModule"
 
+/** @brief Coffee Toolbar 플러그인에서 사용할 Slate 명령을 등록합니다. */
 void FToolbarCommands::RegisterCommands()
 {
 	UI_COMMAND(PluginAction, "CoffeeToolbar", "Execute CoffeeToolbar action", EUserInterfaceActionType::Button, FInputChord());

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Common/FToolbarStyle.cpp
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Common/FToolbarStyle.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file FToolbarStyle.cpp
+ * @brief Coffee Toolbar 플러그인의 Slate 스타일 등록을 구현합니다.
+ */
 #include "Common/FToolbarStyle.h"
 #include "Settings/UToolbarSettings.h"
 #include "Framework/Application/SlateApplication.h"
@@ -14,11 +18,13 @@ const FVector2D Icon20x20(20.0f, 20.0f);
 
 TSharedPtr<FSlateStyleSet> FToolbarStyle::Instance = nullptr;
 
+/** @brief Coffee Toolbar에 등록된 Slate 스타일을 반환합니다. */
 const ISlateStyle& FToolbarStyle::Get()
 {
 	return *Instance;
 }
 
+/** @brief Coffee Toolbar 스타일 세트를 Slate 스타일 레지스트리에 등록합니다. */
 void FToolbarStyle::Initialize()
 {
 	if (!Instance.IsValid())
@@ -28,6 +34,7 @@ void FToolbarStyle::Initialize()
 	}
 }
 
+/** @brief Coffee Toolbar 스타일 세트를 등록 해제하고 정리합니다. */
 void FToolbarStyle::Shutdown()
 {
 	FSlateStyleRegistry::UnRegisterSlateStyle(*Instance);
@@ -35,12 +42,14 @@ void FToolbarStyle::Shutdown()
 	Instance.Reset();
 }
 
+/** @brief Coffee Toolbar 스타일 세트의 이름 식별자를 제공합니다. */
 FName FToolbarStyle::GetStyleSetName()
 {
 	static FName StyleSetName(TEXT("FCoffeeToolbarStyle"));
 	return StyleSetName;
 }
 
+/** @brief 스타일 세트 인스턴스를 생성하고 사용자 정의 툴바 아이콘을 등록합니다. */
 TSharedRef<FSlateStyleSet> FToolbarStyle::Create()
 {
 	TSharedRef< FSlateStyleSet > Style = MakeShareable(new FSlateStyleSet("ToolbarStyle"));
@@ -60,6 +69,7 @@ TSharedRef<FSlateStyleSet> FToolbarStyle::Create()
 	return Style;
 }
 
+/** @brief Slate가 초기화된 경우 Slate 텍스처 리소스를 다시 로드합니다. */
 void FToolbarStyle::ReloadTextures()
 {
 	if (FSlateApplication::IsInitialized())

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/FToolbar.cpp
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/FToolbar.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file FToolbar.cpp
+ * @brief Coffee Toolbar 모듈의 라이프사이클과 메뉴 등록 로직을 구현합니다.
+ */
 #include "FToolbar.h"
 #include "Common/FToolbarStyle.h"
 #include "Common/FToolbarCommands.h"
@@ -18,6 +22,7 @@
 
 #define LOCTEXT_NAMESPACE "FDoppleToolbar"
 
+/** @brief 툴바 기능들을 초기화하고 메뉴 확장을 등록합니다. */
 void FToolbar::StartupModule()
 {
 	FToolbarStyle::Initialize();
@@ -32,6 +37,7 @@ void FToolbar::StartupModule()
 	UToolMenus::RegisterStartupCallback(FSimpleMulticastDelegate::FDelegate::CreateRaw(this, &FToolbar::RegisterMenus));
 }
 
+/** @brief 툴바 콘텐츠를 등록 해제하고 기능 인스턴스를 해제합니다. */
 void FToolbar::ShutdownModule()
 {
 	UToolMenus::UnRegisterStartupCallback(this);
@@ -43,6 +49,7 @@ void FToolbar::ShutdownModule()
 	FToolbarCommands::Unregister();
 }
 
+/** @brief 레벨 에디터 툴바에 Coffee Toolbar 위젯을 추가합니다. */
 void FToolbar::RegisterMenus()
 {
 	FToolMenuOwnerScoped OwnerScoped(this);

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Level/FLevelFeature.cpp
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Level/FLevelFeature.cpp
@@ -1,3 +1,7 @@
+/**
+ * @file FLevelFeature.cpp
+ * @brief Coffee Toolbar에서 레벨 선택을 돕는 헬퍼 기능을 구현합니다.
+ */
 #include "Level/FLevelFeature.h"
 #include "Settings/UToolbarSettings.h" // For UCoffeeToolbarSettings::GetSearchRoots
 #include "Common/FCommon.h" // For GetActiveTargetWorld
@@ -12,10 +16,12 @@
 #include "Editor/UnrealEdEngine.h"
 #include "Modules/ModuleManager.h"
 
+/** @brief 레벨 선택을 위한 기본 상태를 초기화합니다. */
 FLevelFeature::FLevelFeature()
 {
 }
 
+/** @brief 툴바 초기화 시 유효한 레벨이 선택되도록 보장합니다. */
 void FLevelFeature::EnsureDefaultSelection()
 {
     if (!SelectedMapPackage.IsEmpty())
@@ -28,6 +34,7 @@ void FLevelFeature::EnsureDefaultSelection()
     SelectedMapPackage = Worlds[0].PackageName.ToString();
 }
 
+/** @brief 설정된 검색 경로를 사용해 월드 에셋 목록을 수집합니다. */
 bool FLevelFeature::CollectWorlds(TArray<FAssetData>& OutWorlds) const
 {
     const TArray<FName> Roots = UToolbarSettings::GetSearchRoots();
@@ -59,6 +66,7 @@ bool FLevelFeature::CollectWorlds(TArray<FAssetData>& OutWorlds) const
     return OutWorlds.Num() > 0;
 }
 
+/** @brief 현재 선택된 레벨이 존재하는 패키지를 가리키는지 검증합니다. */
 bool FLevelFeature::EnsureValidSelectedMap() const
 {
     if (SelectedMapPackage.IsEmpty())
@@ -79,6 +87,7 @@ bool FLevelFeature::EnsureValidSelectedMap() const
     return true;
 }
 
+/** @brief 더티 패키지 저장을 유도한 뒤 선택된 맵을 에디터에 로드합니다. */
 bool FLevelFeature::LoadSelectedMap() const
 {
     if (!EnsureValidSelectedMap())
@@ -95,6 +104,7 @@ bool FLevelFeature::LoadSelectedMap() const
     return true;
 }
 
+/** @brief 사용 가능한 레벨 에셋을 나열하는 메뉴를 구성합니다. */
 TSharedRef<SWidget> FLevelFeature::GenerateLevelMenu()
 {
     const TArray<FName> Roots = UToolbarSettings::GetSearchRoots();
@@ -147,6 +157,7 @@ TSharedRef<SWidget> FLevelFeature::GenerateLevelMenu()
     return MenuBuilder.MakeWidget();
 }
 
+/** @brief 메뉴에서 새로운 맵을 선택했을 때의 처리를 담당합니다. */
 void FLevelFeature::OnSelectedMap(FString InLongPackageName)
 {
     this->SelectedMapPackage = MoveTemp(InLongPackageName);
@@ -155,12 +166,14 @@ void FLevelFeature::OnSelectedMap(FString InLongPackageName)
     UE_LOG(LogTemp, Log, TEXT("Selected Level: %s"), *InLongPackageName);
 }
 
+/** @brief 선택된 맵 에셋을 에디터에서 엽니다. */
 void FLevelFeature::OnSelectedMap_Open()
 {
     if (LoadSelectedMap())
         UE_LOG(LogTemp, Log, TEXT("Opened: %s"), *SelectedMapPackage);
 }
 
+/** @brief 현재 활성화된 뷰포트에서 선택된 레벨을 실행합니다. */
 void FLevelFeature::OnSelectedMap_PlaySelectedViewport()
 {
     if (!LoadSelectedMap())
@@ -184,6 +197,7 @@ void FLevelFeature::OnSelectedMap_PlaySelectedViewport()
     }
 }
 
+/** @brief 선택된 맵으로 새로운 뷰포트에서 PIE를 실행합니다. */
 void FLevelFeature::OnSelectedMap_PlayInEditor()
 {
     if (!EnsureValidSelectedMap())

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Screenshot/FScreenshotFeature.cpp
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Screenshot/FScreenshotFeature.cpp
@@ -1,3 +1,7 @@
+/**
+ * @file FScreenshotFeature.cpp
+ * @brief Coffee Toolbar의 스크린샷 캡처 헬퍼 기능을 구현합니다.
+ */
 #include "Screenshot/FScreenshotFeature.h"
 #include "Common/FCommon.h" // For GetActiveTargetWorld
 #include "LevelEditor.h" // For FLevelEditorModule
@@ -8,10 +12,12 @@
 #include "HAL/FileManager.h" // For IFileManager
 #include "HAL/PlatformProcess.h" // For FPlatformProcess
 
+/** @brief 스크린샷 기능의 기본 생성자입니다. */
 FScreenshotFeature::FScreenshotFeature()
 {
 }
 
+/** @brief 활성 뷰포트 또는 PIE 세션에서 스크린샷을 촬영합니다. */
 void FScreenshotFeature::OnCaptureScreenshot()
 {
     // 1) PIE 중이면 게임뷰포트에 고해상도 캡쳐
@@ -40,6 +46,7 @@ void FScreenshotFeature::OnCaptureScreenshot()
         GEditor->Exec(W, TEXT("HighResShot 1"));
 }
 
+/** @brief 촬영된 스크린샷이 저장된 디렉터리를 엽니다. */
 void FScreenshotFeature::OnOpenScreenShotDir()
 {
     FString Dir = FPaths::ScreenShotDir();

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Settings/UToolbarSettings.cpp
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Private/Settings/UToolbarSettings.cpp
@@ -1,9 +1,14 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UToolbarSettings.cpp
+ * @brief Coffee Toolbar 플러그인의 설정 헬퍼 기능을 구현합니다.
+ */
 #include "Settings/UToolbarSettings.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetRegistry/IAssetRegistry.h"
 
+/** @brief 기본 검색 경로를 초기화하고 저장된 설정을 불러옵니다. */
 UToolbarSettings::UToolbarSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
@@ -14,6 +19,12 @@ UToolbarSettings::UToolbarSettings(const FObjectInitializer& ObjectInitializer)
 	ReloadConfig(); // Ensure default values from INI are loaded
 }
 
+/**
+ * @brief 사용자 입력 디렉터리 문자열을 콘텐츠 루트 형식으로 정규화합니다.
+ * @param In 사용자 입력 원본 경로 문자열.
+ * @param OutRoot 에셋 레지스트리와 호환되는 정규화된 루트 경로입니다.
+ * @return 정규화에 성공하여 OutRoot가 채워졌다면 true를 반환합니다.
+ */
 static bool NormalizeUserPath(const FString& In, FName& OutRoot)
 {
 	FString S = In;
@@ -34,6 +45,10 @@ static bool NormalizeUserPath(const FString& In, FName& OutRoot)
 	return true;
 }
 
+/**
+ * @brief 에셋 레지스트리 검증을 거친 레벨 검색 루트 목록을 반환합니다.
+ * @param bFallbackToGame 사용자 경로가 없을 때 /Game을 추가할지 여부입니다.
+ */
 TArray<FName> UToolbarSettings::GetSearchRoots(const bool bFallbackToGame)
 {
 	TArray<FName> Paths;

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Command/FCommandFeature.h
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Command/FCommandFeature.h
@@ -4,15 +4,30 @@
 #include "Widgets/SWidget.h"
 #include "Framework/Commands/UIAction.h"
 
+/**
+ * @file FCommandFeature.h
+ * @brief 명령형 버튼을 담당하는 툴바 기능을 선언합니다.
+ */
+
+/**
+ * @brief 툴바 명령 버튼을 위해 Slate 메뉴를 구성하고 실행 상태를 관리합니다.
+ */
 class FCommandFeature
 {
 public:
+    /** @brief 기본 토글 상태를 초기화하고 명령 매핑을 준비합니다. */
     FCommandFeature();
 
+    /** @brief 툴바용 명령 버튼 메뉴 위젯을 생성합니다. */
     TSharedRef<SWidget> GenerateCommandsMenu();
+
+    /** @brief 전달된 버튼 ID에 매핑된 명령을 실행합니다. */
     void OnExecuteButtonCommand(FName ButtonId);
+
+    /** @brief 지정된 툴바 버튼이 현재 토글되어 있는지 반환합니다. */
     bool IsButtonToggled(FName ButtonId) const;
 
 private:
+    /** @brief 버튼 식별자를 키로 사용하는 명령 버튼의 토글 상태 캐시입니다. */
     TMap<FName, bool> ToggleButtonState;
 };

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Common/FCommon.h
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Common/FCommon.h
@@ -3,9 +3,20 @@
 #include "CoreMinimal.h"
 #include "Styling/AppStyle.h"
 
+/**
+ * @file FCommon.h
+ * @brief Coffee Toolbar 플러그인을 위한 공용 유틸리티 헬퍼를 선언합니다.
+ */
+
+/**
+ * @brief Slate 및 월드 관련 유틸리티를 제공하는 네임스페이스형 헬퍼 클래스입니다.
+ */
 class FCommon
 {
 public:
+    /** @brief 전달된 이름으로 애플리케이션 스타일에서 Slate 아이콘을 조회합니다. */
     static const FSlateIcon GetIcon(FName IconName);
+
+    /** @brief 툴바 액션이 대상으로 삼는 활성 에디터 월드를 반환합니다. */
     static UWorld* GetActiveTargetWorld();
 };

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Common/FToolbarCommands.h
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Common/FToolbarCommands.h
@@ -5,20 +5,31 @@
 #include "Framework/Commands/Commands.h"
 #include "Common/FToolbarStyle.h"
 
+/**
+ * @file FToolbarCommands.h
+ * @brief Coffee Toolbar 플러그인에서 사용하는 명령 바인딩을 선언합니다.
+ */
+
+/**
+ * @brief 툴바 액션에 사용할 Slate UI 명령 기술자를 정의합니다.
+ */
 class FToolbarCommands : public TCommands<FToolbarCommands>
 {
 public:
-	FToolbarCommands()
-		: TCommands<FToolbarCommands>(
-			TEXT("CoffeeToolbar"),
-			NSLOCTEXT("Contexts", "CoffeeToolbar", "CoffeeToolbar Plugin"),
-			NAME_None,
-			FToolbarStyle::GetStyleSetName())
-	{
-	}
+        /** @brief 지역화 컨텍스트와 스타일 참조를 설정하여 명령 세트를 구성합니다. */
+        FToolbarCommands()
+                : TCommands<FToolbarCommands>(
+                        TEXT("CoffeeToolbar"),
+                        NSLOCTEXT("Contexts", "CoffeeToolbar", "CoffeeToolbar Plugin"),
+                        NAME_None,
+                        FToolbarStyle::GetStyleSetName())
+        {
+        }
 
-	virtual void RegisterCommands() override;
+        /** @brief 툴바 액션에 사용할 Slate 명령을 등록합니다. */
+        virtual void RegisterCommands() override;
 
 public:
-	TSharedPtr<FUICommandInfo> PluginAction;
+        /** @brief 플러그인의 주요 동작을 실행하는 UI 명령 기술자입니다. */
+        TSharedPtr<FUICommandInfo> PluginAction;
 };

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Common/FToolbarStyle.h
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Common/FToolbarStyle.h
@@ -4,18 +4,37 @@
 
 #include "Styling/SlateStyle.h"
 
+/**
+ * @file FToolbarStyle.h
+ * @brief Coffee Toolbar 플러그인이 사용하는 Slate 스타일 세트를 선언합니다.
+ */
+
+/**
+ * @brief 툴바 위젯에 사용할 Slate 브러시 리소스를 등록하고 제공합니다.
+ */
 class FToolbarStyle
 {
 public:
-	static void Initialize();
-	static void Shutdown();
-	static void ReloadTextures();
-	static const ISlateStyle& Get();
-	static FName GetStyleSetName();
+        /** @brief 스타일 세트를 Slate 스타일 레지스트리에 등록합니다. */
+        static void Initialize();
+
+        /** @brief 스타일 세트를 제거하고 참조된 리소스를 해제합니다. */
+        static void Shutdown();
+
+        /** @brief 디스크상의 리소스가 변경된 경우 텍스처를 다시 로드합니다. */
+        static void ReloadTextures();
+
+        /** @brief 브러시 조회에 사용할 Slate 스타일 인스턴스를 반환합니다. */
+        static const ISlateStyle& Get();
+
+        /** @brief Slate 스타일 세트를 참조할 때 사용할 이름을 반환합니다. */
+        static FName GetStyleSetName();
 
 private:
-	static TSharedRef< class FSlateStyleSet > Create();
+        /** @brief 기본 이미지와 아이콘 등록을 포함한 스타일 세트를 생성합니다. */
+        static TSharedRef<class FSlateStyleSet> Create();
 
 private:
-	static TSharedPtr< class FSlateStyleSet > Instance;
+        /** @brief 등록된 Slate 스타일을 보관하는 싱글턴 인스턴스입니다. */
+        static TSharedPtr<class FSlateStyleSet> Instance;
 };

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/FToolbar.h
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/FToolbar.h
@@ -8,17 +8,33 @@
 #include "Level/FLevelFeature.h"
 #include "Screenshot/FScreenshotFeature.h"
 
+/**
+ * @file FToolbar.h
+ * @brief CoffeeToolbar 플러그인의 주요 모듈 구현을 선언합니다.
+ */
+
+/**
+ * @brief Coffee Toolbar 기능을 에디터에 연결하는 모듈 구현입니다.
+ */
 class FToolbar : public IModuleInterface
 {
 public:
-	virtual void StartupModule() override;
-	virtual void ShutdownModule() override;
+        /** @brief 툴바 기능을 초기화하고 Slate 메뉴 확장을 등록합니다. */
+        virtual void StartupModule() override;
 
-	
+        /** @brief 등록된 메뉴를 해제하고 툴바 기능을 정리합니다. */
+        virtual void ShutdownModule() override;
+
 private:
-	void RegisterMenus();
+        /** @brief 에디터 확장 프레임워크에 툴바 메뉴와 버튼을 등록합니다. */
+        void RegisterMenus();
 
-	TUniquePtr<FCommandFeature> CommandFeature;
-	TUniquePtr<FLevelFeature> LevelFeature;
-	TUniquePtr<FScreenshotFeature> ScreenshotFeature;
+        /** @brief 툴바에서 명령 단축 기능을 제공하는 모듈입니다. */
+        TUniquePtr<FCommandFeature> CommandFeature;
+
+        /** @brief 레벨 관련 유틸리티 버튼을 제공하는 기능입니다. */
+        TUniquePtr<FLevelFeature> LevelFeature;
+
+        /** @brief 스크린샷 캡처 헬퍼를 제공하는 기능입니다. */
+        TUniquePtr<FScreenshotFeature> ScreenshotFeature;
 };

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Level/FLevelFeature.h
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Level/FLevelFeature.h
@@ -5,24 +5,49 @@
 #include "Framework/Commands/UIAction.h"
 #include "AssetRegistry/AssetData.h" // For FAssetData
 
+/**
+ * @file FLevelFeature.h
+ * @brief 툴바에 레벨 선택 컨트롤을 제공하는 기능을 선언합니다.
+ */
+
+/**
+ * @brief 빠른 레벨 전환을 위한 월드 검색과 에디터 명령을 처리합니다.
+ */
 class FLevelFeature
 {
 public:
+    /** @brief 기본 상태를 설정하고 저장된 선택을 불러옵니다. */
     FLevelFeature();
 
+    /** @brief 레벨 선택 항목을 포함한 Slate 위젯을 구성합니다. */
     TSharedRef<SWidget> GenerateLevelMenu();
+
+    /** @brief 선택된 맵 패키지 이름을 저장합니다. */
     void OnSelectedMap(FString InLongPackageName);
+
+    /** @brief 선택된 맵 에셋을 에디터에서 엽니다. */
     void OnSelectedMap_Open();
+
+    /** @brief 선택된 맵으로 현재 뷰포트에서 PIE를 시작합니다. */
     void OnSelectedMap_PlaySelectedViewport();
+
+    /** @brief 선택된 맵으로 새로운 뷰포트에서 PIE를 실행합니다. */
     void OnSelectedMap_PlayInEditor();
 
+    /** @brief 시작 이후에도 유효한 기본 맵 선택이 존재하도록 보장합니다. */
     void EnsureDefaultSelection();
 
 private:
+    /** @brief 설정된 검색 경로에서 발견 가능한 맵 에셋을 모두 수집합니다. */
     bool CollectWorlds(TArray<FAssetData>& OutWorlds) const;
+
+    /** @brief 선택된 맵 에셋이 여전히 존재하는지 검증합니다. */
     bool EnsureValidSelectedMap() const;
+
+    /** @brief 현재 선택된 맵 패키지를 에디터에 로드합니다. */
     bool LoadSelectedMap() const;
 
-    public:
+public:
+    /** @brief 현재 선택된 맵의 패키지 경로입니다. */
     FString SelectedMapPackage;
 };

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Screenshot/FScreenshotFeature.h
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Screenshot/FScreenshotFeature.h
@@ -3,11 +3,23 @@
 #include "CoreMinimal.h"
 #include "Widgets/SWidget.h" // Not strictly needed here, but good practice for UI features
 
+/**
+ * @file FScreenshotFeature.h
+ * @brief 툴바의 스크린샷 워크플로우 버튼을 위한 헬퍼를 선언합니다.
+ */
+
+/**
+ * @brief 스크린샷 촬영과 폴더 탐색 동작을 제공합니다.
+ */
 class FScreenshotFeature
 {
 public:
+    /** @brief 기본 스크린샷 설정 상태를 구성합니다. */
     FScreenshotFeature();
 
+    /** @brief 언리얼 자동화 라이브러리를 사용해 스크린샷을 촬영합니다. */
     void OnCaptureScreenshot();
+
+    /** @brief 촬영된 스크린샷이 저장된 디렉터리를 엽니다. */
     void OnOpenScreenShotDir();
 };

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Settings/FToolbarButtonInfo.h
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Settings/FToolbarButtonInfo.h
@@ -1,37 +1,42 @@
-﻿#pragma once
+#pragma once
 
 #include "CoreMinimal.h"
 #include "FToolbarButtonInfo.generated.h"
 
+/**
+ * @file FToolbarButtonInfo.h
+ * @brief 커스터마이즈 가능한 Coffee Toolbar 버튼 정보를 선언합니다.
+ */
 USTRUCT(BlueprintType)
 struct FToolbarButtonInfo
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
-	/** 각 버튼을 구별하는 고유한 이름입니다. */
-	UPROPERTY(EditAnywhere, Category="Button Info")
-	FName Id;
+        /** 각 버튼을 구분하는 고유한 이름입니다. */
+        UPROPERTY(EditAnywhere, Category="Button Info")
+        FName Id;
 
-	/** 툴바에 표시될 버튼의 이름입니다. */
-	UPROPERTY(EditAnywhere, Category="Button Info")
-	FString Label;
+        /** 툴바에 표시될 버튼의 이름입니다. */
+        UPROPERTY(EditAnywhere, Category="Button Info")
+        FString Label;
 
-	/** 버튼에 마우스를 올렸을 때 나타나는 설명입니다. */
-	UPROPERTY(EditAnywhere, Category="Button Info")
-	FString Tooltip;
+        /** 버튼에 마우스를 올렸을 때 나타나는 설명입니다. */
+        UPROPERTY(EditAnywhere, Category="Button Info")
+        FString Tooltip;
 
-	/** 버튼을 클릭했을 때 실행될 콘솔 명령어입니다. */	UPROPERTY(EditAnywhere, Category="Button Info")
-	FString Command;
+        /** 버튼을 클릭했을 때 실행될 콘솔 명령어입니다. */
+        UPROPERTY(EditAnywhere, Category="Button Info")
+        FString Command;
 
-	/** 
-	 * 버튼에 표시될 아이콘입니다. 
-	 * - 에디터 내장 아이콘: `EditorStyle.GraphEditor.Play` 와 같이 `.` 이 포함된 이름을 사용합니다.
-	 * - 사용자 정의 아이콘: `Plugins/CoffeeToolbar/Resources/` 폴더에 있는 이미지 파일의 이름(확장자 제외)을 사용합니다. (예: `MyIcon`)
-	 */
-	UPROPERTY(EditAnywhere, Category="Button Info")
-	FName Icon;
+        /**
+         * 버튼에 표시될 아이콘입니다.
+         * - 에디터 내장 아이콘: `EditorStyle.GraphEditor.Play`와 같이 `.`을 포함한 스타일명을 사용합니다.
+         * - 사용자 정의 아이콘: `Plugins/CoffeeToolbar/Resources/` 폴더에 있는 이미지 파일 이름(확장자 제외)을 사용합니다. (예: `MyIcon`)
+         */
+        UPROPERTY(EditAnywhere, Category="Button Info")
+        FName Icon;
 
-	/** true로 설정하면 껐다 켰다 할 수 있는 토글 버튼이 됩니다. */
-	UPROPERTY(EditAnywhere, Category="Button Info")
-	bool bIsToggleButton = false;
+        /** true로 설정하면 토글 가능한 버튼으로 동작합니다. */
+        UPROPERTY(EditAnywhere, Category="Button Info")
+        bool bIsToggleButton = false;
 };

--- a/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Settings/UToolbarSettings.h
+++ b/Plugins/CoffeeToolbar/Source/CoffeeToolbar/Public/Settings/UToolbarSettings.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
 #pragma once
 
@@ -6,32 +6,54 @@
 #include "Engine/DeveloperSettings.h"
 #include "UToolbarSettings.generated.h"
 
+/**
+ * @file UToolbarSettings.h
+ * @brief Coffee Toolbar 플러그인을 구성하기 위한 개발자 설정을 선언합니다.
+ */
+
+/**
+ * @brief 툴바 버튼 배치와 기능 토글을 정의하는 개발자 설정입니다.
+ */
 UCLASS(Config=ToolbarSettings)
 class COFFEETOOLBAR_API UToolbarSettings : public UDeveloperSettings
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 public:
-	UToolbarSettings(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
-	
-	virtual FName GetCategoryName() const override { return TEXT("Plugins"); }
-	virtual FName GetSectionName()  const override { return TEXT("Level Selector"); }
+        /** @brief 합리적인 기본값으로 설정 객체를 구성합니다. */
+        UToolbarSettings(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
 
-	static TArray<FName> GetSearchRoots(const bool bFallbackToGame = true);
-	
-	UPROPERTY(EditAnywhere, Config, Category="Search")
-	TArray<FDirectoryPath> ExtraSearchPaths;
+        /** @brief 프로젝트 설정 패널에서 사용되는 설정 카테고리를 반환합니다. */
+        virtual FName GetCategoryName() const override { return TEXT("Plugins"); }
 
-	UPROPERTY(EditAnywhere, Config, Category="Toolbar")
-	TArray<FToolbarButtonInfo> ToolbarButtons;
+        /** @brief 설정 그룹에 대한 지역화된 섹션 이름을 반환합니다. */
+        virtual FName GetSectionName()  const override { return TEXT("Level Selector"); }
 
+        /**
+         * @brief 레벨 선택 헬퍼가 사용할 검색 루트 경로를 수집합니다.
+         * @param bFallbackToGame 사용자 지정 경로가 없을 때 게임 콘텐츠 디렉터리를 포함할지 여부입니다.
+         */
+        static TArray<FName> GetSearchRoots(const bool bFallbackToGame = true);
 
-	UPROPERTY(EditAnywhere, Config, Category="Features")
-	bool bEnableLevelFeature = true;
-	UPROPERTY(EditAnywhere, Config, Category="Features")
-	bool bEnableScreenshotFeature = true;
-	UPROPERTY(EditAnywhere, Config, Category="Features")
-	bool bEnableCommandFeature = true;
+        /** @brief 레벨을 탐색할 때 추가로 확인할 디렉터리 목록입니다. */
+        UPROPERTY(EditAnywhere, Config, Category="Search")
+        TArray<FDirectoryPath> ExtraSearchPaths;
+
+        /** @brief Slate 항목을 정의하는 툴바 버튼 설명자입니다. */
+        UPROPERTY(EditAnywhere, Config, Category="Toolbar")
+        TArray<FToolbarButtonInfo> ToolbarButtons;
+
+        /** @brief true일 때 레벨 관련 툴바 기능을 활성화합니다. */
+        UPROPERTY(EditAnywhere, Config, Category="Features")
+        bool bEnableLevelFeature = true;
+
+        /** @brief true일 때 스크린샷 헬퍼 기능을 활성화합니다. */
+        UPROPERTY(EditAnywhere, Config, Category="Features")
+        bool bEnableScreenshotFeature = true;
+
+        /** @brief true일 때 명령 버튼 기능을 활성화합니다. */
+        UPROPERTY(EditAnywhere, Config, Category="Features")
+        bool bEnableCommandFeature = true;
 };
 
 	

--- a/Source/CoffeeLibrary/Actor/Private/AListActorManager.cpp
+++ b/Source/CoffeeLibrary/Actor/Private/AListActorManager.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file AListActorManager.cpp
+ * @brief AListActorManager 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "AListActorManager.h"
 
 #if WITH_EDITOR

--- a/Source/CoffeeLibrary/Actor/Private/UListActorComponent.cpp
+++ b/Source/CoffeeLibrary/Actor/Private/UListActorComponent.cpp
@@ -1,3 +1,7 @@
+/**
+ * @file UListActorComponent.cpp
+ * @brief 액터 수집을 돕는 에디터 헬퍼 컴포넌트 구현을 제공합니다.
+ */
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
 

--- a/Source/CoffeeLibrary/Actor/Private/UOrbitalBehaviorComponent.cpp
+++ b/Source/CoffeeLibrary/Actor/Private/UOrbitalBehaviorComponent.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UOrbitalBehaviorComponent.cpp
+ * @brief UOrbitalBehaviorComponent 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UOrbitalBehaviorComponent.h"
 #include "GameFramework/Actor.h"
 

--- a/Source/CoffeeLibrary/Actor/Private/UTweenAnimInstance.cpp
+++ b/Source/CoffeeLibrary/Actor/Private/UTweenAnimInstance.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UTweenAnimInstance.cpp
+ * @brief UTweenAnimInstance 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UTweenAnimInstance.h"
 #include "Kismet/KismetMathLibrary.h"
 

--- a/Source/CoffeeLibrary/Actor/Public/AListActorManager.h
+++ b/Source/CoffeeLibrary/Actor/Public/AListActorManager.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file AListActorManager.h
+ * @brief AListActorManager 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/CoffeeLibrary/Actor/Public/UListActorComponent.h
+++ b/Source/CoffeeLibrary/Actor/Public/UListActorComponent.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UListActorComponent.h
+ * @brief UListActorComponent 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/CoffeeLibrary/Actor/Public/UOrbitalBehaviorComponent.h
+++ b/Source/CoffeeLibrary/Actor/Public/UOrbitalBehaviorComponent.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UOrbitalBehaviorComponent.h
+ * @brief UOrbitalBehaviorComponent 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"
@@ -17,6 +21,7 @@ class COFFEELIBRARY_API UOrbitalBehaviorComponent : public UActorComponent
         GENERATED_BODY()
 
 public:
+        /** @brief 기본 속성값을 초기화합니다. */
         UOrbitalBehaviorComponent();
 
         /** @brief 타겟 중심(앵커) 보간 속도. 0이면 즉시 스냅. */
@@ -79,9 +84,10 @@ protected:
 
 private:
         // 내부 상태
-	float   AngleDeg  = 0.f;
-	float   TimeAcc   = 0.f;
-	FVector AnchorLoc = FVector::ZeroVector;
+        float   AngleDeg  = 0.f;
+        float   TimeAcc   = 0.f;
+        FVector AnchorLoc = FVector::ZeroVector;
 
-	void Tick_TargetFloat(float DeltaTime);
+        /** @brief 타겟 추적 및 위치 보간을 처리하는 내부 함수입니다. */
+        void Tick_TargetFloat(float DeltaTime);
 };

--- a/Source/CoffeeLibrary/Actor/Public/UTweenAnimInstance.h
+++ b/Source/CoffeeLibrary/Actor/Public/UTweenAnimInstance.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UTweenAnimInstance.h
+ * @brief UTweenAnimInstance 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/CoffeeLibrary/CoffeeLibrary.cpp
+++ b/Source/CoffeeLibrary/CoffeeLibrary.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file CoffeeLibrary.cpp
+ * @brief CoffeeLibrary 모듈의 진입점을 구현합니다.
+ */
 #include "CoffeeLibrary.h"
 #include "Modules/ModuleManager.h"
 

--- a/Source/CoffeeLibrary/CoffeeLibrary.h
+++ b/Source/CoffeeLibrary/CoffeeLibrary.h
@@ -4,3 +4,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
+
+/**
+ * @file CoffeeLibrary.h
+ * @brief CoffeeLibrary 모듈의 기본 헤더입니다.
+ */

--- a/Source/CoffeeLibrary/Features/Private/UCommonFunctionLibrary.cpp
+++ b/Source/CoffeeLibrary/Features/Private/UCommonFunctionLibrary.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved.
 
+/**
+ * @file UCommonFunctionLibrary.cpp
+ * @brief UCommonFunctionLibrary 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UCommonFunctionLibrary.h"
 
 #include "Kismet/GameplayStatics.h"

--- a/Source/CoffeeLibrary/Features/Private/UEaseComponent.cpp
+++ b/Source/CoffeeLibrary/Features/Private/UEaseComponent.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UEaseComponent.cpp
+ * @brief UEaseComponent 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UEaseComponent.h"
 
 /** @brief Tick 활성화를 설정한다. */

--- a/Source/CoffeeLibrary/Features/Private/UEaseFunctionLibrary.cpp
+++ b/Source/CoffeeLibrary/Features/Private/UEaseFunctionLibrary.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UEaseFunctionLibrary.cpp
+ * @brief UEaseFunctionLibrary 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 
 #include "UEaseFunctionLibrary.h"
 #include "FEaseHelper.h"

--- a/Source/CoffeeLibrary/Features/Private/UParabolaComponent.cpp
+++ b/Source/CoffeeLibrary/Features/Private/UParabolaComponent.cpp
@@ -1,4 +1,8 @@
-﻿#include "UParabolaComponent.h"
+/**
+ * @file UParabolaComponent.cpp
+ * @brief UParabolaComponent 구현에 대한 Doxygen 주석을 제공합니다.
+ */
+#include "UParabolaComponent.h"
 #include "DrawDebugHelpers.h"
 #include "GameFramework/Actor.h"
 

--- a/Source/CoffeeLibrary/Features/Public/UCommonFunctionLibrary.h
+++ b/Source/CoffeeLibrary/Features/Public/UCommonFunctionLibrary.h
@@ -1,4 +1,8 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+/**
+ * @file UCommonFunctionLibrary.h
+ * @brief UCommonFunctionLibrary 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/CoffeeLibrary/Features/Public/UEaseComponent.h
+++ b/Source/CoffeeLibrary/Features/Public/UEaseComponent.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UEaseComponent.h
+ * @brief UEaseComponent 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/CoffeeLibrary/Features/Public/UEaseFunctionLibrary.h
+++ b/Source/CoffeeLibrary/Features/Public/UEaseFunctionLibrary.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UEaseFunctionLibrary.h
+ * @brief UEaseFunctionLibrary 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/CoffeeLibrary/Features/Public/UParabolaComponent.h
+++ b/Source/CoffeeLibrary/Features/Public/UParabolaComponent.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UParabolaComponent.h
+ * @brief UParabolaComponent 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/CoffeeLibrary/Features/Public/USequenceActivatable.h
+++ b/Source/CoffeeLibrary/Features/Public/USequenceActivatable.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file USequenceActivatable.h
+ * @brief USequenceActivatable 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/CoffeeLibrary/Shared/Private/FLogWriter.cpp
+++ b/Source/CoffeeLibrary/Shared/Private/FLogWriter.cpp
@@ -1,3 +1,7 @@
+/**
+ * @file FLogWriter.cpp
+ * @brief FLogWriter 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "FLogWriter.h"
 
 #include "HAL/PlatformFileManager.h"

--- a/Source/CoffeeLibrary/Shared/Private/GameLogging.cpp
+++ b/Source/CoffeeLibrary/Shared/Private/GameLogging.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file GameLogging.cpp
+ * @brief GameLogging 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "GameLogging.h"
 
 // 일반 게임 로깅을 위한 로그 카테고리를 실제로 정의합니다.

--- a/Source/CoffeeLibrary/Shared/Private/NetworkLog.cpp
+++ b/Source/CoffeeLibrary/Shared/Private/NetworkLog.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file NetworkLog.cpp
+ * @brief NetworkLog 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "NetworkLog.h"
 #include "HAL/FileManager.h"
 #include "Misc/Paths.h"

--- a/Source/CoffeeLibrary/Shared/Public/FComponentHelper.h
+++ b/Source/CoffeeLibrary/Shared/Public/FComponentHelper.h
@@ -1,4 +1,8 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+/**
+ * @file FComponentHelper.h
+ * @brief FComponentHelper 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/CoffeeLibrary/Shared/Public/FEaseHelper.h
+++ b/Source/CoffeeLibrary/Shared/Public/FEaseHelper.h
@@ -1,4 +1,8 @@
-﻿#pragma once
+/**
+ * @file FEaseHelper.h
+ * @brief FEaseHelper 선언에 대한 Doxygen 주석을 제공합니다.
+ */
+#pragma once
 
 UENUM(BlueprintType)
 enum class EEaseType : uint8

--- a/Source/CoffeeLibrary/Shared/Public/FLogWriter.h
+++ b/Source/CoffeeLibrary/Shared/Public/FLogWriter.h
@@ -1,4 +1,7 @@
-
+/**
+ * @file FLogWriter.h
+ * @brief FLogWriter 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/CoffeeLibrary/Shared/Public/FMaterialHelper.h
+++ b/Source/CoffeeLibrary/Shared/Public/FMaterialHelper.h
@@ -1,10 +1,20 @@
-﻿#pragma once
+#pragma once
 
+/**
+ * @file FMaterialHelper.h
+ * @brief 머티리얼 인스턴스와 안전하게 상호작용하기 위한 헬퍼를 제공합니다.
+ */
 struct FMaterialHelper
 {
-	static FLinearColor GetVectorParameterValueSafe(
-		UMaterialInstanceDynamic* MaterialInstance, 
-		const FName& ParamName)
+        /**
+         * @brief 머티리얼 인스턴스에서 벡터 파라미터 값을 안전하게 조회합니다.
+         * @param MaterialInstance 확인할 머티리얼 인스턴스입니다.
+         * @param ParamName 읽어올 벡터 파라미터 이름입니다.
+         * @return 값이 존재하면 해당 파라미터를, 인스턴스가 없으면 검정색을 반환합니다.
+         */
+        static FLinearColor GetVectorParameterValueSafe(
+                UMaterialInstanceDynamic* MaterialInstance,
+                const FName& ParamName)
 	{
 		if (MaterialInstance == nullptr)
 		{

--- a/Source/CoffeeLibrary/Shared/Public/FMathHelper.h
+++ b/Source/CoffeeLibrary/Shared/Public/FMathHelper.h
@@ -1,4 +1,8 @@
-﻿#pragma once
+/**
+ * @file FMathHelper.h
+ * @brief CoffeeLibrary 전반에서 사용하는 수학 헬퍼를 선언합니다.
+ */
+#pragma once
 
 struct FMathHelper
 {

--- a/Source/CoffeeLibrary/Shared/Public/GameColor.h
+++ b/Source/CoffeeLibrary/Shared/Public/GameColor.h
@@ -1,4 +1,8 @@
-﻿#pragma once
+/**
+ * @file GameColor.h
+ * @brief CoffeeLibrary에서 공유하는 색상 상수를 정의합니다.
+ */
+#pragma once
 
 namespace GameColor
 {

--- a/Source/CoffeeLibrary/Shared/Public/GameLogging.h
+++ b/Source/CoffeeLibrary/Shared/Public/GameLogging.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file GameLogging.h
+ * @brief GameLogging 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/CoffeeLibrary/Shared/Public/NetworkLog.h
+++ b/Source/CoffeeLibrary/Shared/Public/NetworkLog.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file NetworkLog.h
+ * @brief NetworkLog 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Character/Private/AGameCharacter.cpp
+++ b/Source/LatteLibrary/Character/Private/AGameCharacter.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file AGameCharacter.cpp
+ * @brief AGameCharacter 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "AGameCharacter.h"
 
 #include "UStatSystem.h"

--- a/Source/LatteLibrary/Character/Private/APlayerActor.cpp
+++ b/Source/LatteLibrary/Character/Private/APlayerActor.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file APlayerActor.cpp
+ * @brief APlayerActor 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 
 
 #include "APlayerActor.h"

--- a/Source/LatteLibrary/Character/Private/APlayerControl.cpp
+++ b/Source/LatteLibrary/Character/Private/APlayerControl.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file APlayerControl.cpp
+ * @brief APlayerControl 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "APlayerControl.h"
 #include "IControllable.h"
 

--- a/Source/LatteLibrary/Character/Private/UCameraShakeSystem.cpp
+++ b/Source/LatteLibrary/Character/Private/UCameraShakeSystem.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UCameraShakeSystem.cpp
+ * @brief UCameraShakeSystem 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UCameraShakeSystem.h"
 #include "AGameCharacter.h"
 #include "FPadFeedbackData.h"

--- a/Source/LatteLibrary/Character/Private/UFlySystem.cpp
+++ b/Source/LatteLibrary/Character/Private/UFlySystem.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UFlySystem.cpp
+ * @brief UFlySystem 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 
 #include "UFlySystem.h"
 

--- a/Source/LatteLibrary/Character/Private/UHitStopSystem.cpp
+++ b/Source/LatteLibrary/Character/Private/UHitStopSystem.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UHitStopSystem.cpp
+ * @brief UHitStopSystem 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 
 #include "UHitStopSystem.h"
 

--- a/Source/LatteLibrary/Character/Private/UKnockbackSystem.cpp
+++ b/Source/LatteLibrary/Character/Private/UKnockbackSystem.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UKnockbackSystem.cpp
+ * @brief UKnockbackSystem 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 
 #include "UKnockbackSystem.h"
 #include "AGameCharacter.h"

--- a/Source/LatteLibrary/Character/Private/USightSystem.cpp
+++ b/Source/LatteLibrary/Character/Private/USightSystem.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file USightSystem.cpp
+ * @brief USightSystem 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "USightSystem.h"
 #include "GameColor.h"
 #include "Kismet/KismetMathLibrary.h"

--- a/Source/LatteLibrary/Character/Private/UStatSystem.cpp
+++ b/Source/LatteLibrary/Character/Private/UStatSystem.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UStatSystem.cpp
+ * @brief UStatSystem 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UStatSystem.h"
 
 #include "FCharacterInfoData.h"

--- a/Source/LatteLibrary/Character/Public/AGameCharacter.h
+++ b/Source/LatteLibrary/Character/Public/AGameCharacter.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
 #pragma once
 
@@ -9,24 +9,40 @@
 #include "UStatSystem.h"
 #include "AGameCharacter.generated.h"
 
+/**
+ * @file AGameCharacter.h
+ * @brief LatteLibrary 전반에서 사용하는 기반 캐릭터 클래스를 선언합니다.
+ */
+
+/**
+ * @brief 전투, 능력치, 애니메이션 헬퍼를 연결하는 기반 캐릭터 구현입니다.
+ */
 UCLASS(Blueprintable, BlueprintType, ClassGroup=(Dopple))
 class LATTELIBRARY_API AGameCharacter : public ACharacter
 {
 	GENERATED_BODY()
 
 public:
-	AGameCharacter();
+        /** @brief 기본 구성 요소와 서브 시스템을 초기화합니다. */
+        AGameCharacter();
 
 protected:
-	virtual void BeginPlay() override;
-	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+        /** @brief 게임 시작 시 서브 시스템을 연결합니다. */
+        virtual void BeginPlay() override;
+
+        /** @brief 플레이 종료 시 리소스를 해제합니다. */
+        virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 	
 private:
-	void BindMontageDelegates(UAnimInstance* Anim);
-	void UnbindMontageDelegates(UAnimInstance* Anim);
+        /** @brief 몽타주 알림 처리 델리게이트를 바인딩합니다. */
+        void BindMontageDelegates(UAnimInstance* Anim);
+
+        /** @brief 몽타주 알림 델리게이트 연결을 해제합니다. */
+        void UnbindMontageDelegates(UAnimInstance* Anim);
 
 	UFUNCTION()
-	void OnMontageNotifyBegin(FName NotifyName, const FBranchingPointNotifyPayload& Payload);
+        /** @brief 몽타주 노티파이 시작 시 호출되는 콜백입니다. */
+        void OnMontageNotifyBegin(FName NotifyName, const FBranchingPointNotifyPayload& Payload);
 	
 public:
 	FORCEINLINE UArrowComponent* GetBodyPart(EBodyPartType Part) const

--- a/Source/LatteLibrary/Character/Public/APlayerActor.h
+++ b/Source/LatteLibrary/Character/Public/APlayerActor.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file APlayerActor.h
+ * @brief APlayerActor 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 
 
 #pragma once

--- a/Source/LatteLibrary/Character/Public/APlayerControl.h
+++ b/Source/LatteLibrary/Character/Public/APlayerControl.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file APlayerControl.h
+ * @brief APlayerControl 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Character/Public/IControllable.h
+++ b/Source/LatteLibrary/Character/Public/IControllable.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file IControllable.h
+ * @brief IControllable 인터페이스 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Character/Public/UCameraShakeSystem.h
+++ b/Source/LatteLibrary/Character/Public/UCameraShakeSystem.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UCameraShakeSystem.h
+ * @brief UCameraShakeSystem 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Character/Public/UFlySystem.h
+++ b/Source/LatteLibrary/Character/Public/UFlySystem.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UFlySystem.h
+ * @brief UFlySystem 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Character/Public/UHitStopSystem.h
+++ b/Source/LatteLibrary/Character/Public/UHitStopSystem.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UHitStopSystem.h
+ * @brief UHitStopSystem 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Character/Public/UKnockbackSystem.h
+++ b/Source/LatteLibrary/Character/Public/UKnockbackSystem.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UKnockbackSystem.h
+ * @brief UKnockbackSystem 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Character/Public/USightSystem.h
+++ b/Source/LatteLibrary/Character/Public/USightSystem.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file USightSystem.h
+ * @brief USightSystem 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Character/Public/UStatSystem.h
+++ b/Source/LatteLibrary/Character/Public/UStatSystem.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UStatSystem.h
+ * @brief UStatSystem 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Common/Private/UGameFunctionLibrary.cpp
+++ b/Source/LatteLibrary/Common/Private/UGameFunctionLibrary.cpp
@@ -1,3 +1,7 @@
+/**
+ * @file UGameFunctionLibrary.cpp
+ * @brief UGameFunctionLibrary 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UGameFunctionLibrary.h"
 
 TSubclassOf<UGameDamageType> UGameFunctionLibrary::GetDamageTypeClass(EDamageType InType)

--- a/Source/LatteLibrary/Common/Public/GameEvent.h
+++ b/Source/LatteLibrary/Common/Public/GameEvent.h
@@ -1,4 +1,8 @@
-﻿#pragma once
+/**
+ * @file GameEvent.h
+ * @brief GameEvent 네임스페이스에 대한 Doxygen 주석을 제공합니다.
+ */
+#pragma once
 
 namespace GameEvent
 {

--- a/Source/LatteLibrary/Common/Public/UGameDamageType.h
+++ b/Source/LatteLibrary/Common/Public/UGameDamageType.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UGameDamageType.h
+ * @brief UGameDamageType 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 
 #pragma once
 

--- a/Source/LatteLibrary/Common/Public/UGameFunctionLibrary.h
+++ b/Source/LatteLibrary/Common/Public/UGameFunctionLibrary.h
@@ -1,3 +1,7 @@
+/**
+ * @file UGameFunctionLibrary.h
+ * @brief UGameFunctionLibrary 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Data/Private/UCharacterData.cpp
+++ b/Source/LatteLibrary/Data/Private/UCharacterData.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UCharacterData.cpp
+ * @brief UCharacterData 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UCharacterData.h"
 #include "GameLogging.h"
 #include "Animation/AnimMontage.h"

--- a/Source/LatteLibrary/Data/Public/EBodyPartType.h
+++ b/Source/LatteLibrary/Data/Public/EBodyPartType.h
@@ -1,4 +1,8 @@
-﻿#pragma once
+/**
+ * @file EBodyPartType.h
+ * @brief EBodyPartType 열거형에 대한 Doxygen 주석을 제공합니다.
+ */
+#pragma once
 
 UENUM(BlueprintType)
 enum class EBodyPartType : uint8

--- a/Source/LatteLibrary/Data/Public/ECharacterType.h
+++ b/Source/LatteLibrary/Data/Public/ECharacterType.h
@@ -1,4 +1,8 @@
-﻿#pragma once
+/**
+ * @file ECharacterType.h
+ * @brief ECharacterType 열거형에 대한 Doxygen 주석을 제공합니다.
+ */
+#pragma once
 
 UENUM(BlueprintType)
 enum class ECharacterType : uint8

--- a/Source/LatteLibrary/Data/Public/EDamageType.h
+++ b/Source/LatteLibrary/Data/Public/EDamageType.h
@@ -1,4 +1,8 @@
-﻿#pragma once
+/**
+ * @file EDamageType.h
+ * @brief EDamageType 열거형에 대한 Doxygen 주석을 제공합니다.
+ */
+#pragma once
 
 UENUM(BlueprintType)
 enum class EDamageType : uint8

--- a/Source/LatteLibrary/Data/Public/EGameSoundType.h
+++ b/Source/LatteLibrary/Data/Public/EGameSoundType.h
@@ -1,4 +1,8 @@
-﻿#pragma once
+/**
+ * @file EGameSoundType.h
+ * @brief EGameSoundType 열거형에 대한 Doxygen 주석을 제공합니다.
+ */
+#pragma once
 
 UENUM(BlueprintType)
 enum class EGameSoundType : uint8

--- a/Source/LatteLibrary/Data/Public/EMontageType.h
+++ b/Source/LatteLibrary/Data/Public/EMontageType.h
@@ -1,4 +1,8 @@
-﻿#pragma once
+/**
+ * @file EMontageType.h
+ * @brief EMontageType 열거형에 대한 Doxygen 주석을 제공합니다.
+ */
+#pragma once
 
 UENUM(BlueprintType)
 enum class EMontageType : uint8

--- a/Source/LatteLibrary/Data/Public/EVFXType.h
+++ b/Source/LatteLibrary/Data/Public/EVFXType.h
@@ -1,4 +1,8 @@
-﻿#pragma once
+/**
+ * @file EVFXType.h
+ * @brief EVFXType 열거형에 대한 Doxygen 주석을 제공합니다.
+ */
+#pragma once
 
 UENUM(BlueprintType)
 enum class EVFXType : uint8

--- a/Source/LatteLibrary/Data/Public/FCharacterAssetData.h
+++ b/Source/LatteLibrary/Data/Public/FCharacterAssetData.h
@@ -1,4 +1,8 @@
-﻿#pragma once
+/**
+ * @file FCharacterAssetData.h
+ * @brief FCharacterAssetData 구조체에 대한 Doxygen 주석을 제공합니다.
+ */
+#pragma once
 
 #include "CoreMinimal.h"
 #include "ECharacterType.h"

--- a/Source/LatteLibrary/Data/Public/FCharacterInfoData.h
+++ b/Source/LatteLibrary/Data/Public/FCharacterInfoData.h
@@ -1,4 +1,8 @@
-﻿#pragma once
+/**
+ * @file FCharacterInfoData.h
+ * @brief FCharacterInfoData 구조체에 대한 Doxygen 주석을 제공합니다.
+ */
+#pragma once
 
 #include "CoreMinimal.h"
 #include "ECharacterType.h"

--- a/Source/LatteLibrary/Data/Public/FHitStopData.h
+++ b/Source/LatteLibrary/Data/Public/FHitStopData.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file FHitStopData.h
+ * @brief FHitStopData 구조체에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Data/Public/FKnockbackData.h
+++ b/Source/LatteLibrary/Data/Public/FKnockbackData.h
@@ -1,3 +1,7 @@
+/**
+ * @file FKnockbackData.h
+ * @brief FKnockbackData 구조체에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Data/Public/FPadFeedbackData.h
+++ b/Source/LatteLibrary/Data/Public/FPadFeedbackData.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file FPadFeedbackData.h
+ * @brief FPadFeedbackData 구조체에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Data/Public/UCharacterData.h
+++ b/Source/LatteLibrary/Data/Public/UCharacterData.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UCharacterData.h
+ * @brief UCharacterData 데이터 자산에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Data/Public/USoundData.h
+++ b/Source/LatteLibrary/Data/Public/USoundData.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file USoundData.h
+ * @brief USoundData 데이터 자산에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Data/Public/UVFXDataAsset.h
+++ b/Source/LatteLibrary/Data/Public/UVFXDataAsset.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UVFXDataAsset.h
+ * @brief UVFXDataAsset 데이터 자산에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/LatteLibrary.cpp
+++ b/Source/LatteLibrary/LatteLibrary.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file LatteLibrary.cpp
+ * @brief LatteLibrary 모듈의 진입점을 구현합니다.
+ */
 #include "LatteLibrary.h"
 #include "Modules/ModuleManager.h"
 

--- a/Source/LatteLibrary/LatteLibrary.h
+++ b/Source/LatteLibrary/LatteLibrary.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file LatteLibrary.h
+ * @brief LatteLibrary 모듈의 기본 헤더입니다.
+ */
 
 #pragma once
 

--- a/Source/LatteLibrary/Manager/Private/UBroadcastManger.cpp
+++ b/Source/LatteLibrary/Manager/Private/UBroadcastManger.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UBroadcastManger.cpp
+ * @brief UBroadcastManger 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UBroadcastManger.h"
 
 void UBroadcastManger::SendMessage(const FString& InMsg)

--- a/Source/LatteLibrary/Manager/Private/UDelayTaskManager.cpp
+++ b/Source/LatteLibrary/Manager/Private/UDelayTaskManager.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UDelayTaskManager.cpp
+ * @brief UDelayTaskManager 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UDelayTaskManager.h"
 #include "Engine/World.h"
 #include "TimerManager.h"

--- a/Source/LatteLibrary/Manager/Private/UGameDataManager.cpp
+++ b/Source/LatteLibrary/Manager/Private/UGameDataManager.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UGameDataManager.cpp
+ * @brief UGameDataManager 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UGameDataManager.h"
 #include "GameLogging.h"
 #include "FCharacterAssetData.h"

--- a/Source/LatteLibrary/Manager/Private/UGameSoundManager.cpp
+++ b/Source/LatteLibrary/Manager/Private/UGameSoundManager.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UGameSoundManager.cpp
+ * @brief UGameSoundManager 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UGameSoundManager.h"
 #include "USoundData.h"
 #include "Components/AudioComponent.h"

--- a/Source/LatteLibrary/Manager/Private/UGameVFXManager.cpp
+++ b/Source/LatteLibrary/Manager/Private/UGameVFXManager.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UGameVFXManager.cpp
+ * @brief UGameVFXManager 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UGameVFXManager.h"
 
 #include "EDamageType.h"

--- a/Source/LatteLibrary/Manager/Private/UObjectPoolManager.cpp
+++ b/Source/LatteLibrary/Manager/Private/UObjectPoolManager.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UObjectPoolManager.cpp
+ * @brief UObjectPoolManager 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UObjectPoolManager.h"
 #include "Engine/World.h"
 #include "GameFramework/CharacterMovementComponent.h"

--- a/Source/LatteLibrary/Manager/Private/USequenceManager.cpp
+++ b/Source/LatteLibrary/Manager/Private/USequenceManager.cpp
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file USequenceManager.cpp
+ * @brief USequenceManager 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 
 #include "USequenceManager.h"
 #include "USequenceActivatable.h"

--- a/Source/LatteLibrary/Manager/Public/Macro.h
+++ b/Source/LatteLibrary/Manager/Public/Macro.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file Macro.h
+ * @brief Manager 모듈에서 공통으로 사용하는 매크로 정의에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 

--- a/Source/LatteLibrary/Manager/Public/UBroadcastManger.h
+++ b/Source/LatteLibrary/Manager/Public/UBroadcastManger.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UBroadcastManger.h
+ * @brief UBroadcastManger 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Manager/Public/UDelayTaskManager.h
+++ b/Source/LatteLibrary/Manager/Public/UDelayTaskManager.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UDelayTaskManager.h
+ * @brief UDelayTaskManager 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Manager/Public/UGameDataManager.h
+++ b/Source/LatteLibrary/Manager/Public/UGameDataManager.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UGameDataManager.h
+ * @brief UGameDataManager 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Manager/Public/UGameSoundManager.h
+++ b/Source/LatteLibrary/Manager/Public/UGameSoundManager.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UGameSoundManager.h
+ * @brief UGameSoundManager 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Manager/Public/UGameVFXManager.h
+++ b/Source/LatteLibrary/Manager/Public/UGameVFXManager.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UGameVFXManager.h
+ * @brief UGameVFXManager 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Manager/Public/UObjectPoolManager.h
+++ b/Source/LatteLibrary/Manager/Public/UObjectPoolManager.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UObjectPoolManager.h
+ * @brief UObjectPoolManager 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Manager/Public/USequenceManager.h
+++ b/Source/LatteLibrary/Manager/Public/USequenceManager.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file USequenceManager.h
+ * @brief USequenceManager 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Network/Private/ANetworkTesterActor.cpp
+++ b/Source/LatteLibrary/Network/Private/ANetworkTesterActor.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file ANetworkTesterActor.cpp
+ * @brief ANetworkTesterActor 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "ANetworkTesterActor.h"
 #include "UHttpNetworkSystem.h"
 #include "GameLogging.h"

--- a/Source/LatteLibrary/Network/Private/NetworkData.cpp
+++ b/Source/LatteLibrary/Network/Private/NetworkData.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file NetworkData.cpp
+ * @brief NetworkData 구조 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "NetworkData.h"
 
 #include "JsonObjectConverter.h"

--- a/Source/LatteLibrary/Network/Private/UCustomNetworkSettings.cpp
+++ b/Source/LatteLibrary/Network/Private/UCustomNetworkSettings.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UCustomNetworkSettings.cpp
+ * @brief UCustomNetworkSettings 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UCustomNetworkSettings.h"
 #include "Misc/CommandLine.h"
 

--- a/Source/LatteLibrary/Network/Private/UHttpNetworkSystem.cpp
+++ b/Source/LatteLibrary/Network/Private/UHttpNetworkSystem.cpp
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UHttpNetworkSystem.cpp
+ * @brief UHttpNetworkSystem 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 
 #include "UHttpNetworkSystem.h"
 #include "NetworkLog.h"

--- a/Source/LatteLibrary/Network/Private/UWebSocketSystem.cpp
+++ b/Source/LatteLibrary/Network/Private/UWebSocketSystem.cpp
@@ -1,3 +1,7 @@
+/**
+ * @file UWebSocketSystem.cpp
+ * @brief UWebSocketSystem 구현에 대한 Doxygen 주석을 제공합니다.
+ */
 #include "UWebSocketSystem.h"
 #include "NetworkLog.h"
 #include "ENetworkLogType.h"

--- a/Source/LatteLibrary/Network/Public/ANetworkTesterActor.h
+++ b/Source/LatteLibrary/Network/Public/ANetworkTesterActor.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file ANetworkTesterActor.h
+ * @brief ANetworkTesterActor 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Network/Public/ENetworkLogType.h
+++ b/Source/LatteLibrary/Network/Public/ENetworkLogType.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file ENetworkLogType.h
+ * @brief ENetworkLogType 열거형에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Network/Public/NetworkData.h
+++ b/Source/LatteLibrary/Network/Public/NetworkData.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file NetworkData.h
+ * @brief NetworkData 구조체 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Network/Public/UCustomNetworkSettings.h
+++ b/Source/LatteLibrary/Network/Public/UCustomNetworkSettings.h
@@ -1,5 +1,9 @@
-﻿// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
+// Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UCustomNetworkSettings.h
+ * @brief UCustomNetworkSettings 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Network/Public/UHttpNetworkSystem.h
+++ b/Source/LatteLibrary/Network/Public/UHttpNetworkSystem.h
@@ -1,5 +1,9 @@
 // Copyright (c) 2025 Doppleddiggong. All rights reserved. Unauthorized copying, modification, or distribution of this file, via any medium is strictly prohibited. Proprietary and confidential.
 
+/**
+ * @file UHttpNetworkSystem.h
+ * @brief UHttpNetworkSystem 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"

--- a/Source/LatteLibrary/Network/Public/UWebSocketSystem.h
+++ b/Source/LatteLibrary/Network/Public/UWebSocketSystem.h
@@ -1,3 +1,7 @@
+/**
+ * @file UWebSocketSystem.h
+ * @brief UWebSocketSystem 선언에 대한 Doxygen 주석을 제공합니다.
+ */
 #pragma once
 
 #include "CoreMinimal.h"


### PR DESCRIPTION
## Summary
- localize CoffeeToolbar Doxygen file and member comments to Korean as requested
- translate CoffeeLibrary and LatteLibrary documentation stubs to Korean for consistent output

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68dcf8a30abc8329ae8f25852ddb2595